### PR TITLE
Change install directory for Fossa CLI in license-check workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Fossa CLI
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
       - name: Scan for dependencies and licenses
         run: |
-          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze


### PR DESCRIPTION
Fixes issue where all of the sudden the Fossa CLI tool was failing to install during workflow actions because of permissions issues on their default install directory.

It now installs into the local working directory and executes from there.

Tested changes here: https://github.com/jdonenine/cass-operator/runs/3124668353