### PR TITLE
Miles/full query logging endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ local.properties
 *.ipr
 out/
 .idea_modules/
+.vscode/

--- a/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/CassandraAPI4x.java
+++ b/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/CassandraAPI4x.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
@@ -66,7 +67,37 @@ public class CassandraAPI4x implements CassandraAPI
     private static final Logger logger = LoggerFactory.getLogger(CassandraAPI4x.class);
 
     private static final Supplier<SeedProvider> seedProvider = Suppliers.memoize(() -> new K8SeedProvider4x());
-
+    
+    @Override
+    public void enableFullQuerylog() 
+    {
+        logger.debug("Getting FQL options and calling enableFullQueryLogger.");
+        FullQueryLoggerOptions fqlOpts = DatabaseDescriptor.getFullQueryLogOptions();
+        StorageService.instance.enableFullQueryLogger(fqlOpts.log_dir, 
+            fqlOpts.roll_cycle, 
+            fqlOpts.block, 
+            fqlOpts.max_queue_weight, 
+            fqlOpts.max_log_size, 
+            fqlOpts.archive_command, 
+            fqlOpts.max_archive_retries);
+    }
+    
+    @Override
+    public void disableFullQuerylog() 
+    {
+        logger.debug("Stopping FullQueryLogger.");
+        StorageService.instance.stopFullQueryLogger();
+    }
+    
+    @Override
+    public boolean isFullQueryLogEnabled() 
+    {
+        boolean isEnabled = StorageService.instance.isFullQueryLogEnabled();
+        logger.debug("Querying whether full query logging is enabled. Result is {}", isEnabled);
+        return isEnabled;
+        
+    }
+    
     @Override
     public void decommission(boolean force) throws InterruptedException
     {

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -66,6 +66,34 @@ public class NodeOpsProvider
         RpcRegistry.unregister(RPC_CLASS_NAME);
     }
 
+    @Rpc(name = "setFullQuerylog")
+    public void setFullQuerylog(@RpcParam(name="enabled") boolean fullQueryLoggingEnabled) throws UnsupportedOperationException
+    {
+        logger.debug("Attempting to set full query logging to " + fullQueryLoggingEnabled);
+        // Warning: bad design here. Default implementation will throw UnsupportedOperationException at runtime. Comparing strings to get versions is also ugly.
+        String cassVersion = ShimLoader.instance.get().getStorageService().getReleaseVersion();
+        if (Integer.parseInt(cassVersion.split("\\.")[0]) < 4){
+            logger.error("Full query logging is not available in Cassandra < 4x. This call is going to fail.");
+        }
+        if (fullQueryLoggingEnabled) {
+            ShimLoader.instance.get().enableFullQuerylog();
+        } else {
+            ShimLoader.instance.get().disableFullQuerylog();
+        }
+    }
+
+    @Rpc(name = "isFullQueryLogEnabled")
+    public boolean isFullQueryLogEnabled() throws UnsupportedOperationException
+    {
+        String cassVersion = ShimLoader.instance.get().getStorageService().getReleaseVersion();
+        logger.debug("Attempting to retrieve full query logging status for cassandra version" + cassVersion + ".");
+        if (Integer.parseInt(cassVersion.split("\\.")[0]) < 4){
+            logger.error("Full query logging is not available in Cassandra < 4x. This call is going to fail.");
+        }
+        logger.debug("Calling ShimLoader.instance.get().isFullQueryLogEnabled()");
+        return ShimLoader.instance.get().isFullQueryLogEnabled();
+    }
+
     @Rpc(name = "reloadSeeds")
     public List<String> reloadSeeds()
     {

--- a/management-api-agent-dse-6.8/src/main/java/com/datastax/mgmtapi/shim/DseAPI68.java
+++ b/management-api-agent-dse-6.8/src/main/java/com/datastax/mgmtapi/shim/DseAPI68.java
@@ -68,7 +68,7 @@ public class DseAPI68 implements CassandraAPI
     private static final Logger logger = LoggerFactory.getLogger(DseAPI68.class);
 
     private static final Supplier<SeedProvider> seedProvider = Suppliers.memoize(K8SeedProviderDse68::new)::get;
-
+    
     @Override
     public void decommission(boolean force) throws InterruptedException
     {

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/shims/CassandraAPI.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/shims/CassandraAPI.java
@@ -29,6 +29,23 @@ import org.apache.cassandra.transport.Server;
  */
 public interface CassandraAPI
 {
+    
+    default public void enableFullQuerylog()
+    {
+        throw new UnsupportedOperationException("FQL is only supported on OSS Cassandra > 4x.");
+    }
+    
+    default public void disableFullQuerylog() 
+    {
+        throw new UnsupportedOperationException("FQL is only supported on OSS Cassandra > 4x.");
+    }
+    
+    default public boolean isFullQueryLogEnabled() 
+    {
+        throw new UnsupportedOperationException("FQL is only supported on OSS Cassandra > 4x.");
+        
+    }
+
     void decommission(boolean force) throws InterruptedException;
 
     Map<List<Long>, List<String>> checkConsistencyLevel(String consistencyLevelName, Integer rfPerDc);

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -355,6 +355,39 @@
         }
       }
     },
+    "/api/v0/ops/node/fullquerylogging" : {
+      "put" : {
+        "summary" : "Enable or disable full query logging facility.",
+        "operationId" : "setFullQuerylog",
+        "parameters" : [ {
+          "name" : "enabled",
+          "in" : "query",
+          "schema" : {
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Get whether full query logging is enabled.",
+        "operationId" : "isFullQueryLogEnabled",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/ops/node/decommission" : {
       "post" : {
         "summary" : "Decommission the *node I am connecting to*",

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -348,6 +348,35 @@ public class NodeOpsResources
         });
     }
 
+    @POST
+    @Path("/fullquerylogging")
+    @Operation(summary = "Enable or disable full query logging facility.")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response setFullQuerylog(@QueryParam(value="enabled")boolean fullQueryLoggingEnabled)
+    {
+        return handle(() ->
+        {   logger.debug("Running CALL NodeOps.setFullQuerylog(?) " + fullQueryLoggingEnabled);
+            cqlService.executePreparedStatement(app.dbUnixSocketFile, "CALL NodeOps.setFullQuerylog(?)", fullQueryLoggingEnabled);
+            return Response.ok("OK").build();
+        });
+    }
+
+    @GET
+    @Path("/fullquerylogging")
+    @Operation(summary = "Get whether full query logging is enabled.")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response isFullQueryLogEnabled()
+    {
+        return handle(() ->
+        {
+            logger.debug("CALL NodeOps.isFullQueryLogEnabled()");
+            Row row = cqlService.executePreparedStatement(app.dbUnixSocketFile, "CALL NodeOps.isFullQueryLogEnabled()").one();
+            Object queryResponse = null;
+            if (row != null) { queryResponse = row.getObject(0); }
+            return Response.ok(Entity.json(queryResponse)).build();
+        });
+    }
+
     static Response handle(Callable<Response> action)
     {
         try


### PR DESCRIPTION
Draft PR. @emerkle826 I think this is wrong in a few ways but thought I'd get a draft out.

1. First up, I'm having some issues running the integration tests. Probably user error 😅
2. I also think I'm abusing `management-api-agent-common` by adding a 4x-only method to the `CassandraAPI.java`. I would have thought that this method should appear only in the 4x implementation `CassandraAPI4x`.

I'm inclined to think the RPC method `enableFullQuerylog()` [body](https://github.com/k8ssandra/management-api-for-apache-cassandra/blob/a47a4f8bb849a39523d13effe5fa1532fd5813b7/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java#L70) should narrow the API instance by casting like this (solves problem 2 above by allowing us to remove the method from the common interface), but I don't think we can import the `CassandraAPI4x` type without creating a circular dependancy?

```
try {
            CassandraAPI cassAPI = (CassandraAPI4x) ShimLoader.instance.get();
            ShimLoader.instance.get().enableFullQuerylog();
            
        } catch (ClassCastException e ) {
            logger.error("Can't cast CassandraAPI instance to CassandraAPI4x. Full query logging is not supported on Cassandra < 4, are you sure you are running Cassandra 4.x +?");
            throw new UnsupportedOperationException()

        }
```

What are your thoughts on how to tackle this problem?