### PR TITLE
Non-root verification / bump Tini

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -56,7 +56,7 @@ RUN mkdir ${USER_HOME_PATH} && \
     chown -R cassandra:root ${CASSANDRA_PATH} ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} && \
     chmod -R g+w ${CASSANDRA_PATH} ${MAAC_PATH} ${MCAC_PATH}
 
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -67,10 +67,9 @@ RUN mkdir ${USER_HOME_PATH} && \
     chown -R cassandra:root ${CASSANDRA_PATH} ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} && \
     chmod -R g+w ${CASSANDRA_PATH} ${MAAC_PATH} ${MCAC_PATH}
 
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
-
 RUN set -eux; \
   rm -fr /etc/apt/sources.list.d/*; \
   rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Reviewed as part of k8ssandra security [epic](https://k8ssandra.atlassian.net/browse/K8SSAND-705).

- Related to [this effort](https://k8ssandra.atlassian.net/browse/K8SSAND-802) as part of security hardening for running entrypoint script as non-root.
- The primary mgmt-api images used by k8ssandra at current were examined with an update to Tini's version where needed.
- Two images were using `cassandra` user and one using `dse` user.


