### PR TITLE
Use default heap of 128m

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -45,7 +45,6 @@ ENV CASSANDRA_LOGS ${CASSANDRA_PATH}/logs
 # https://datastax.jira.com/browse/DB-4627
 # https://issues.apache.org/jira/browse/CASSANDRA-16027
 ENV MGMT_API_LOG_DIR /var/log/cassandra
-ENV MGMT_API_HEAP_SIZE 16m
 
 COPY --from=builder /build/management-api-agent-4.x/target/datastax-mgmtapi-agent-4.x-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/

--- a/Dockerfile-dse-68
+++ b/Dockerfile-dse-68
@@ -41,7 +41,6 @@ ENV CASSANDRA_LOGS ${CASSANDRA_PATH}/logs
 # https://datastax.jira.com/browse/DB-4627
 # https://issues.apache.org/jira/browse/CASSANDRA-16027
 ENV MGMT_API_LOG_DIR /var/log/cassandra
-ENV MGMT_API_HEAP_SIZE 16m
 
 COPY --from=builder /build/management-api-agent-dse-6.8/target/datastax-mgmtapi-agent-dse-6.8-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -56,7 +56,6 @@ ENV CASSANDRA_LOGS ${CASSANDRA_PATH}/logs
 # https://datastax.jira.com/browse/DB-4627
 # https://issues.apache.org/jira/browse/CASSANDRA-16027
 ENV MGMT_API_LOG_DIR /var/log/cassandra
-ENV MGMT_API_HEAP_SIZE 16m
 
 COPY --from=builder /build/management-api-agent-3.x/target/datastax-mgmtapi-agent-3.x-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar
 COPY --from=builder /build/management-api-server/target/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar ${MAAC_PATH}/


### PR DESCRIPTION
Remove the setting of `MGMT_API_HEAP_SIZE` in the Dockerfiles and let the default of `128m` in the entry point script be used. For development environments, size can be overridden if desired.