### PR TITLE
Publish Docker images after PR merges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,19 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cassandra-version: ['3.11', '4.0']
-        docker-file: [Dockerfile-oss,Dockerfile-4_0]
-        build-target: [oss311,oss40]
-        # exclude invalid combinations
-        exclude:
+        include:
           - cassandra-version: '3.11'
-            docker-file: Dockerfile-4_0
-          - cassandra-version: '3.11'
-            build-target: oss40
-          - cassandra-version: '4.0'
-            docker-file: Dockerfile-oss
-          - cassandra-version: '4.0'
+            docker-file: Dockerfile-oss40
             build-target: oss311
+          - cassandra-version: '4.0'
+            docker-file: Dockerfile-4_0
+            build-target: oss40
     steps:
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         include:
           - cassandra-version: '3.11'
-            docker-file: Dockerfile-oss40
+            docker-file: Dockerfile-oss
             build-target: oss311
           - cassandra-version: '4.0'
             docker-file: Dockerfile-4_0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,3 +69,105 @@ jobs:
             MAVEN_OPTS="-Drun311tests=${{ matrix.run311tests }} -Drun40tests=${{ matrix.run40tests }}"
           fi
           mvn -B -q install --file pom.xml $MAVEN_OPTS
+  publish-oss:
+    name: Publish ${{ matrix.cassandra-version }} Cassandra image
+    needs: build
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push'}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cassandra-version: ['3.11', '4.0']
+        docker-file: [Dockerfile-oss,Dockerfile-4_0]
+        build-target: [oss311,oss40]
+        # exclude invalid combinations
+        exclude:
+          - cassandra-version: '3.11'
+            docker-file: Dockerfile-4_0
+          - cassandra-version: '3.11'
+            build-target: oss40
+          - cassandra-version: '4.0'
+            docker-file: Dockerfile-oss
+          - cassandra-version: '4.0'
+            build-target: oss311
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      # Setup metadata based on the commit/tag that will be used for tagging the image
+      # Only build and publish a commit based tag
+      - name: Setup Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: k8ssandra/cass-management-api
+          tags: type=sha,prefix=${{ matrix.cassandra-version }}-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: ${{ matrix.docker-file }}
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.build-target }}
+  publish-dse:
+    name: Publish DSE image
+    needs: build
+    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push'}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Setup Maven settings file
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+             </server>
+           </servers>
+          </settings>
+          EOF
+          cp ~/.m2/settings.xml settings.xml
+      # Setup metadata based on the commit/tag that will be used for tagging the image
+      # Only build and publish a commit based tag
+      - name: Setup Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: datastax/dse-mgmtapi-6_8
+          tags: type=sha,prefix=dse68-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile-dse-68
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -59,6 +59,7 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg CASSANDRA_VERSION=4.0.1 \
+            --tag k8ssandra/cass-management-api:4.0 \
             --tag k8ssandra/cass-management-api:4.0.1 \
             --tag k8ssandra/cass-management-api:4.0.1-$RELEASE_VERSION \
             --file Dockerfile-4_0 \
@@ -151,6 +152,7 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg CASSANDRA_VERSION=3.11.11 \
+            --tag k8ssandra/cass-management-api:3.11 \
             --tag k8ssandra/cass-management-api:3.11.11 \
             --tag k8ssandra/cass-management-api:3.11.11-$RELEASE_VERSION \
             --file Dockerfile-oss \

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ docker run -p 8080:8080 -it --rm mgmtapi-dse
 
 # Making changes
 
+## Design Summary
+
 The architecture of this repository is laid as follows, front-to-back:
 
 1. The `management-api-server/doc/openapi.json` documents the API.
@@ -209,6 +211,27 @@ The architecture of this repository is laid as follows, front-to-back:
 5. The `management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java` routes commands through to specific versioned instances of `CassandraAPI` which is implemented in the version 3x/4x subprojects as `CassandraAPI4x`/`CassandraAPI3x`.
 
 Any change to add endpoints or features will need to make modifications in each of the above components to ensure that they propagate through.
+
+## Published Docker images
+
+When PRs are merged into the `master` branch, if all of the integration tests pass, the CI process will build and publish all supported Docker images with GitHub commit SHA tags. These images are not intended to be used in production. They are meant for facilitating testing with dependent projects.
+
+The format of the Docker image tag for OSS Cassandra based images will be `<Cassandra version>-<git commit sha>`. For example, if the SHA for the commit to master is `3e99e87`, then the Cassandra 3.11.11 image tag would be `3.11.11-3e99e87`. The full docker coordinates would be `k8ssandra/cass-management-api:3.11.11-3e99e87`. Once published, these images can be used for testing in dependent projects (such as [cass-operator](https://github.com/k8ssandra/cass-operator)). Testing in dependent projects is a manual process at this time and is not automated.
+
+## Official Release process
+
+When the `master` branch is ready for release, all that needs to be done is to create a git `tag` and push the tag. When a git tag is pushed, a GitHub Action will kick off that builds the release versions of the Docker images and publish the to DockerHub. The release tag should be formatted as:
+
+    v0.1.X
+
+where `X` is incremental for each release. If the most recent release version is `v0.1.32`, then to cut the next (v0.1.33) release, do the following:
+
+    git checkout master
+    git pull
+    git tag v0.1.33
+    git push origin refs/tags/v0.1.33
+
+Once the tag is pushed, the release process will start and build the Docker images as well as the Maven artifacts. The images are automatically pushed to DockerHub and the Maven artifacts are published and attached to the GitHub release.
 
 # CLI Help
   The CLI help covers the different options:


### PR DESCRIPTION
Fixes #157 

Adds a process to publish Docker images when PRs are merged to master with a Docker tag of `<Cassandra-version>-<git commit sha>`. For example:

    k8ssandra/cass-management-api:4.0.1-3e99e87

Also updates the README with this information as well as Release tagging info.