### PR TITLE
Fix NPE in CallStatus and change return code to 404

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -92,6 +92,9 @@ public class NodeOpsProvider
     public Map<String, String> getJobStatus(@RpcParam(name="job_id") String jobId) {
         Map<String, String> resultMap = new HashMap<>();
         Job jobWithId = service.getJobWithId(jobId);
+        if(jobWithId == null) {
+            return resultMap;
+        }
         resultMap.put("id", jobWithId.getJobId());
         resultMap.put("type", jobWithId.getJobType());
         resultMap.put("status", jobWithId.getStatus().name());

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -127,6 +127,9 @@ public class K8OperatorResources
     public Response getJobStatus(@QueryParam(value="job_id") String jobId) {
         return handle(() -> {
             Map<String, String> jobResponse = (Map<String, String>) ResponseTools.getSingleRowResponse(app.dbUnixSocketFile, cqlService, "CALL NodeOps.jobStatus(?)", jobId);
+            if(jobResponse.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND).entity(jobResponse).build();
+            }
             return Response.ok(jobResponse, MediaType.APPLICATION_JSON).build();
         });
     }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/K8OperatorResourcesTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/K8OperatorResourcesTest.java
@@ -541,6 +541,28 @@ public class K8OperatorResourcesTest {
         assertEquals("CLEANUP", jobDetails.getJobType());
     }
 
+    @Test
+    public void testJobStatusNotExisting() throws Exception {
+        Context context = setup();
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(context.cqlService.executePreparedStatement(any(), anyString(), anyString())).thenReturn(mockResultSet);
+        Row mockRow = mock(Row.class);
+
+        when(mockResultSet.one()).thenReturn(mockRow);
+
+        Map<String, String> jobDetailsRow = new HashMap<>();
+
+        when(mockRow.getObject(0)).thenReturn(jobDetailsRow);
+
+        MockHttpResponse response = getJobStatusWithId(context, "/ops/executor/job?job_id=0");
+
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatus());
+        verify(context.cqlService).executePreparedStatement(any(), eq("CALL NodeOps.jobStatus(?)"), anyString());
+
+        String json = response.getContentAsString();
+        assertEquals("{}", json);
+    }
+
     private MockHttpResponse getJobStatusWithId(Context context, String path) throws URISyntaxException {
         MockHttpRequest request = MockHttpRequest
                 .get(ROOT_PATH + path)


### PR DESCRIPTION
If the job did not exists (the pod crashed while executing the job), then management-api would return NPE and 500. This PR changes the behaviour to return 404 in that case indicating the job_id did not match any known jobs to the jobExecutor.