### PR TITLE
Add OpenAPI doc generation [K8SSAND-967]

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -14,7 +14,7 @@ COPY management-api-common/pom.xml ./management-api-common/pom.xml
 COPY management-api-server/pom.xml ./management-api-server/pom.xml
 # this duplicates work done in the next steps, but this should provide
 # a solid cache layer that only gets reset on pom.xml changes
-RUN mvn -q -ff -T 1C install && rm -rf target
+RUN mvn -q -ff -T 1C install -DskipOpenApi && rm -rf target
 
 COPY management-api-agent-common ./management-api-agent-common
 COPY management-api-agent-3.x ./management-api-agent-3.x

--- a/Dockerfile-dse-68
+++ b/Dockerfile-dse-68
@@ -16,7 +16,7 @@ COPY management-api-server/pom.xml ./management-api-server/pom.xml
 COPY settings.xml settings.xml /root/.m2/
 # this duplicates work done in the next steps, but this should provide
 # a solid cache layer that only gets reset on pom.xml changes
-RUN mvn -q -ff -T 1C install -Pdse && rm -rf target
+RUN mvn -q -ff -T 1C install -Pdse -DskipOpenApi && rm -rf target
 
 COPY management-api-agent-common ./management-api-agent-common
 COPY management-api-agent-3.x ./management-api-agent-3.x

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -14,7 +14,7 @@ COPY management-api-common/pom.xml ./management-api-common/pom.xml
 COPY management-api-server/pom.xml ./management-api-server/pom.xml
 # this duplicates work done in the next steps, but this should provide
 # a solid cache layer that only gets reset on pom.xml changes
-RUN mvn -q -ff -T 1C install && rm -rf target
+RUN mvn -q -ff -T 1C install -DskipOpenApi && rm -rf target
 
 COPY management-api-agent-common ./management-api-agent-common
 COPY management-api-agent-3.x ./management-api-agent-3.x

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ git commit
 
 ## API Client Generation
 
-In addition to automatic OpenAPI document generation, a Golang client is also generated during the build. The client is built using the [OpenAPI Tools generator Maven plugin](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin) and can be used by Go projects to interact with the Management API. The client generation happens during the `process-classes` phase of the Maven build so that changes to the API implementation can be compiled into an OpenAPI document spec file [during the compile phase](#changes-to-api-endpoints) of the build. The client code is generated in the `target` directory under the [management-api-server](management-api-server) sub-module and should be located at
+In addition to automatic OpenAPI document generation, a Golang client can be generated during the build by enabling the `clientgen` Maven profile. The client is built using the [OpenAPI Tools generator Maven plugin](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin) and can be used by Go projects to interact with the Management API. The client generation happens during the `process-classes` phase of the Maven build so that changes to the API implementation can be compiled into an OpenAPI document spec file [during the compile phase](#changes-to-api-endpoints) of the build. The client code is generated in the `target` directory under the [management-api-server](management-api-server) sub-module and should be located at
 
 ```sh
 management-api-server/target/generated-sources/openapi
@@ -231,7 +231,7 @@ management-api-server/target/generated-sources/openapi
 To generate the client, run the following from the root of the project:
 
 ```sh
-mvn clean process-classes
+mvn clean process-classes -Pclientgen
 ```
 
 ## Published Docker images

--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ The architecture of this repository is laid as follows, front-to-back:
 
 Any change to add endpoints or features will need to make modifications in each of the above components to ensure that they propagate through.
 
+## Changes to API endpoints
+
+If you are adding a new endpoint, removing an endpoint, or otherwise changing the public API of an endpoint, you will need to re-generate the OpenAPI/Swagger document. The document lives at [management-api-server/doc/openapi.json](management-api-server/doc/openapi.json) and is regenerated during the build's `compile` phase. If your changes to code cause the API to change, you will need to perform a local `mvn compile` to regenerate the document and then add the change to your git commit.
+
+```sh
+mvn clean compile
+git add management-api-server/doc/openapi.json
+git commit
+```
+
+## API Client Generation
+
+In addition to automatic OpenAPI document generation, a Golang client is also generated during the build. The client is built using the [OpenAPI Tools generator Maven plugin](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin) and can be used by Go projects to interact with the Management API. The client generation happens during the `process-classes` phase of the Maven build so that changes to the API implementation can be compiled into an OpenAPI document spec file [during the compile phase](#changes-to-api-endpoints) of the build. The client code is generated in the `target` directory under the [management-api-server](management-api-server) sub-module and should be located at
+
+```sh
+management-api-server/target/generated-sources/openapi
+```
+
+To generate the client, run the following from the root of the project:
+
+```sh
+mvn clean process-classes
+```
+
 ## Published Docker images
 
 When PRs are merged into the `master` branch, if all of the integration tests pass, the CI process will build and publish all supported Docker images with GitHub commit SHA tags. These images are not intended to be used in production. They are meant for facilitating testing with dependent projects.

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -239,7 +239,6 @@
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
-          "required" : true,
           "schema" : {
             "type" : "string"
           }
@@ -837,6 +836,7 @@
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
+          "required" : true,
           "schema" : {
             "type" : "string"
           }

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -1,61 +1,22 @@
 {
   "openapi" : "3.0.1",
   "info" : {
-    "title" : "Management API for Apache Cassandra™",
     "description" : "This is a Restful service for operating Apache Cassandra.  You can find out more about the Management API on [Github](http://github.com/k8ssandra/management-api-for-apache-cassandra)",
     "license" : {
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
+    "title" : "Management API for Apache Cassandra™",
     "version" : "0.1"
   },
   "paths" : {
-    "/api/v0/ops/auth/role" : {
-      "post" : {
-        "summary" : "Creates a new user role",
-        "operationId" : "createRole",
-        "parameters" : [ {
-          "name" : "username",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "is_superuser",
-          "in" : "query",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "can_login",
-          "in" : "query",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "password",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
     "/api/v0/lifecycle/configure" : {
       "post" : {
         "description" : "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started",
         "operationId" : "configureNode",
         "parameters" : [ {
-          "name" : "profile",
           "in" : "query",
+          "name" : "profile",
           "schema" : {
             "type" : "string"
           }
@@ -81,77 +42,170 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "*/*" : { }
-            }
+            },
+            "description" : "default response"
           }
         }
       }
     },
-    "/api/v0/probes/cluster" : {
+    "/api/v0/lifecycle/pid" : {
       "get" : {
-        "summary" : "Indicated whether the Cassandra cluster is able to achieve the specified consistency",
-        "operationId" : "checkClusterConsistency",
+        "description" : "The PID of Cassandra/DSE, if it's running",
+        "operationId" : "getPID",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "*/*" : { }
+            },
+            "description" : "default response"
+          }
+        }
+      }
+    },
+    "/api/v0/lifecycle/start" : {
+      "post" : {
+        "description" : "Starts Cassandra/DSE",
+        "operationId" : "startNode",
         "parameters" : [ {
-          "name" : "consistency_level",
           "in" : "query",
+          "name" : "profile",
           "schema" : {
             "type" : "string"
           }
         }, {
-          "name" : "rf_per_dc",
           "in" : "query",
+          "name" : "replace_ip",
           "schema" : {
-            "type" : "integer",
-            "format" : "int32"
+            "type" : "string"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "*/*" : { }
-            }
+            },
+            "description" : "default response"
           }
         }
       }
     },
-    "/api/v0/probes/liveness" : {
-      "get" : {
-        "summary" : "Indicates whether this service is running",
-        "operationId" : "checkLiveness",
+    "/api/v0/lifecycle/stop" : {
+      "post" : {
+        "description" : "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called",
+        "operationId" : "stopNode",
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
-              "text/plain" : { }
-            }
+              "*/*" : { }
+            },
+            "description" : "default response"
           }
         }
       }
     },
-    "/api/v0/probes/readiness" : {
+    "/api/v0/metadata/endpoints" : {
       "get" : {
-        "summary" : "Indicates whether the Cassandra service is ready to service requests",
-        "operationId" : "checkReadiness",
+        "operationId" : "getEndpointStates",
         "responses" : {
           "default" : {
-            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Returns this nodes view of the endpoint states of nodes"
+      }
+    },
+    "/api/v0/metadata/localdc" : {
+      "get" : {
+        "operationId" : "getLocalDataCenter",
+        "responses" : {
+          "default" : {
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Returns the DataCenter the local node belongs to"
+      }
+    },
+    "/api/v0/metadata/versions/features" : {
+      "get" : {
+        "operationId" : "getFeatureSet",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Returns the management-api featureSet"
+      }
+    },
+    "/api/v0/metadata/versions/release" : {
+      "get" : {
+        "operationId" : "getReleaseVersion",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Returns the Cassandra release version"
+      }
+    },
+    "/api/v0/ops/auth/role" : {
+      "post" : {
+        "operationId" : "createRole",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "username",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "is_superuser",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "in" : "query",
+          "name" : "can_login",
+          "schema" : {
+            "type" : "boolean"
+          }
+        }, {
+          "in" : "query",
+          "name" : "password",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Creates a new user role"
       }
     },
     "/api/v0/ops/executor/job" : {
       "get" : {
-        "summary" : "Returns Job deatils for the supplied Job ID",
         "operationId" : "getJobStatus",
         "parameters" : [ {
-          "name" : "job_id",
           "in" : "query",
+          "name" : "job_id",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -159,31 +213,38 @@
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "*/*" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Returns Job deatils for the supplied Job ID"
       }
     },
-    "/api/v0/ops/seeds/reload" : {
-      "post" : {
-        "summary" : "Reload the seed node list from the seed provider",
-        "operationId" : "seedReload",
+    "/api/v0/ops/keyspace" : {
+      "get" : {
+        "operationId" : "listKeyspaces",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "keyspaceName",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
-              "*/*" : { }
-            }
+              "application/json" : { }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "List the keyspaces existing in the cluster"
       }
     },
     "/api/v0/ops/keyspace/alter" : {
       "post" : {
-        "summary" : "Alter the replication settings of an existing keyspace",
         "operationId" : "alterKeyspace",
         "requestBody" : {
           "content" : {
@@ -196,17 +257,17 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Alter the replication settings of an existing keyspace"
       }
     },
     "/api/v0/ops/keyspace/cleanup" : {
       "post" : {
-        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.",
         "operationId" : "cleanup",
         "requestBody" : {
           "content" : {
@@ -219,17 +280,17 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing."
       }
     },
     "/api/v0/ops/keyspace/create" : {
       "post" : {
-        "summary" : "Create a new keyspace with the given name and replication settings",
         "operationId" : "createKeyspace",
         "requestBody" : {
           "content" : {
@@ -242,21 +303,48 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Create a new keyspace with the given name and replication settings"
+      }
+    },
+    "/api/v0/ops/keyspace/refresh" : {
+      "post" : {
+        "operationId" : "refresh",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "keyspaceName",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "table",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Load newly placed SSTables to the system without restart"
       }
     },
     "/api/v0/ops/keyspace/replication" : {
       "get" : {
-        "summary" : "Get the replication settings of an existing keyspace",
         "operationId" : "replication",
         "parameters" : [ {
-          "name" : "keyspaceName",
           "in" : "query",
+          "name" : "keyspaceName",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -264,378 +352,176 @@
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "application/json" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
-      }
-    },
-    "/api/v0/ops/keyspace" : {
-      "get" : {
-        "summary" : "List the keyspaces existing in the cluster",
-        "operationId" : "listKeyspaces",
-        "parameters" : [ {
-          "name" : "keyspaceName",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/keyspace/refresh" : {
-      "post" : {
-        "summary" : "Load newly placed SSTables to the system without restart",
-        "operationId" : "refresh",
-        "parameters" : [ {
-          "name" : "keyspaceName",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "table",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/lifecycle/pid" : {
-      "get" : {
-        "description" : "The PID of Cassandra/DSE, if it's running",
-        "operationId" : "getPID",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "*/*" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/lifecycle/start" : {
-      "post" : {
-        "description" : "Starts Cassandra/DSE",
-        "operationId" : "startNode",
-        "parameters" : [ {
-          "name" : "profile",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "replace_ip",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "*/*" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/lifecycle/stop" : {
-      "post" : {
-        "description" : "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called",
-        "operationId" : "stopNode",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "*/*" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/endpoints" : {
-      "get" : {
-        "summary" : "Returns this nodes view of the endpoint states of nodes",
-        "operationId" : "getEndpointStates",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/versions/features" : {
-      "get" : {
-        "summary" : "Returns the management-api featureSet",
-        "operationId" : "getFeatureSet",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/localdc" : {
-      "get" : {
-        "summary" : "Returns the DataCenter the local node belongs to",
-        "operationId" : "getLocalDataCenter",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/versions/release" : {
-      "get" : {
-        "summary" : "Returns the Cassandra release version",
-        "operationId" : "getReleaseVersion",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
+        },
+        "summary" : "Get the replication settings of an existing keyspace"
       }
     },
     "/api/v0/ops/node/assassinate" : {
       "post" : {
-        "summary" : "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode",
         "operationId" : "assassinate",
         "parameters" : [ {
-          "name" : "address",
           "in" : "query",
+          "name" : "address",
           "schema" : {
             "type" : "string"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/snapshots" : {
-      "get" : {
-        "summary" : "Retrieve snapshot details",
-        "operationId" : "getSnapshotDetails",
-        "parameters" : [ {
-          "name" : "snapshotNames",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "keyspaces",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      },
-      "post" : {
-        "summary" : "Take a snapshot",
-        "operationId" : "takeSnapshot",
-        "requestBody" : {
-          "content" : {
-            "*/*" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/TakeSnapshotRequest"
-              }
-            }
+            },
+            "description" : "default response"
           }
         },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "summary" : "Clear snapshots",
-        "operationId" : "clearSnapshots",
+        "summary" : "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode"
+      }
+    },
+    "/api/v0/ops/node/compaction" : {
+      "post" : {
+        "operationId" : "setCompactionThroughput",
         "parameters" : [ {
-          "name" : "snapshotNames",
           "in" : "query",
+          "name" : "value",
           "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "keyspaces",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
+            "type" : "integer",
+            "format" : "int32"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling"
       }
     },
     "/api/v0/ops/node/decommission" : {
       "post" : {
-        "summary" : "Decommission the *node I am connecting to*",
         "operationId" : "decommission",
         "parameters" : [ {
-          "name" : "force",
           "in" : "query",
+          "name" : "force",
           "schema" : {
             "type" : "boolean"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Decommission the *node I am connecting to*"
       }
     },
     "/api/v0/ops/node/drain" : {
       "post" : {
-        "summary" : "Drain the node (stop accepting writes and flush all tables)",
         "operationId" : "drain",
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
-      }
-    },
-    "/api/v0/ops/node/streaminfo" : {
-      "get" : {
-        "summary" : "Retrieve Streaming status information",
-        "operationId" : "getStreamInfo",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
+        },
+        "summary" : "Drain the node (stop accepting writes and flush all tables)"
       }
     },
     "/api/v0/ops/node/fullquerylogging" : {
       "get" : {
-        "summary" : "Get whether full query logging is enabled.",
         "operationId" : "isFullQueryLogEnabled",
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "application/json" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Get whether full query logging is enabled."
       },
       "post" : {
-        "summary" : "Enable or disable full query logging facility.",
         "operationId" : "setFullQuerylog",
         "parameters" : [ {
-          "name" : "enabled",
           "in" : "query",
+          "name" : "enabled",
           "schema" : {
             "type" : "boolean"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Enable or disable full query logging facility."
       }
     },
-    "/api/v0/ops/node/schema/reload" : {
+    "/api/v0/ops/node/hints/truncate" : {
       "post" : {
-        "summary" : "Reload local node schema from system tables",
-        "operationId" : "reloadLocalSchema",
+        "operationId" : "truncateHints",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "host",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified."
+      }
+    },
+    "/api/v0/ops/node/logging" : {
+      "post" : {
+        "operationId" : "setLoggingLevel",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "target",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "rawLevel",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters."
       }
     },
     "/api/v0/ops/node/repair" : {
       "post" : {
-        "summary" : "Execute a nodetool repair operation",
         "operationId" : "repair",
         "requestBody" : {
           "content" : {
@@ -648,101 +534,180 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Execute a nodetool repair operation"
+      }
+    },
+    "/api/v0/ops/node/schema/reload" : {
+      "post" : {
+        "operationId" : "reloadLocalSchema",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Reload local node schema from system tables"
       }
     },
     "/api/v0/ops/node/schema/reset" : {
       "post" : {
-        "summary" : "Reset node's local schema and resync",
         "operationId" : "resetLocalSchema",
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Reset node's local schema and resync"
       }
     },
-    "/api/v0/ops/node/compaction" : {
-      "post" : {
-        "summary" : "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling",
-        "operationId" : "setCompactionThroughput",
+    "/api/v0/ops/node/snapshots" : {
+      "delete" : {
+        "operationId" : "clearSnapshots",
         "parameters" : [ {
-          "name" : "value",
           "in" : "query",
+          "name" : "snapshotNames",
           "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/logging" : {
-      "post" : {
-        "summary" : "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters.",
-        "operationId" : "setLoggingLevel",
-        "parameters" : [ {
-          "name" : "target",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
           }
         }, {
-          "name" : "rawLevel",
           "in" : "query",
+          "name" : "keyspaces",
           "schema" : {
-            "type" : "string"
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Clear snapshots"
+      },
+      "get" : {
+        "operationId" : "getSnapshotDetails",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "snapshotNames",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
-        }
+        }, {
+          "in" : "query",
+          "name" : "keyspaces",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Retrieve snapshot details"
+      },
+      "post" : {
+        "operationId" : "takeSnapshot",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TakeSnapshotRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Take a snapshot"
       }
     },
-    "/api/v0/ops/node/hints/truncate" : {
+    "/api/v0/ops/node/streaminfo" : {
+      "get" : {
+        "operationId" : "getStreamInfo",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "application/json" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Retrieve Streaming status information"
+      }
+    },
+    "/api/v0/ops/seeds/reload" : {
       "post" : {
-        "summary" : "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified.",
-        "operationId" : "truncateHints",
+        "operationId" : "seedReload",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "*/*" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Reload the seed node list from the seed provider"
+      }
+    },
+    "/api/v0/ops/tables" : {
+      "get" : {
+        "operationId" : "listTables",
         "parameters" : [ {
-          "name" : "host",
           "in" : "query",
+          "name" : "keyspaceName",
+          "required" : true,
           "schema" : {
             "type" : "string"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
-              "text/plain" : { }
-            }
+              "application/json" : { }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "List the table names in the given keyspace"
       }
     },
     "/api/v0/ops/tables/compact" : {
       "post" : {
-        "summary" : "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables",
         "operationId" : "compact",
         "requestBody" : {
           "content" : {
@@ -755,17 +720,17 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables"
       }
     },
     "/api/v0/ops/tables/create" : {
       "post" : {
-        "summary" : "Create a new table in an existing keyspace",
         "operationId" : "createTable",
         "requestBody" : {
           "content" : {
@@ -778,17 +743,17 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Create a new table in an existing keyspace"
       }
     },
     "/api/v0/ops/tables/flush" : {
       "post" : {
-        "summary" : "Flush one or more tables",
         "operationId" : "flush",
         "requestBody" : {
           "content" : {
@@ -801,21 +766,21 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Flush one or more tables"
       }
     },
     "/api/v0/ops/tables/garbagecollect" : {
       "post" : {
-        "summary" : "Remove deleted data from one or more tables",
         "operationId" : "garbageCollect",
         "parameters" : [ {
-          "name" : "tombstoneOption",
           "in" : "query",
+          "name" : "tombstoneOption",
           "schema" : {
             "type" : "string"
           }
@@ -831,39 +796,17 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
-      }
-    },
-    "/api/v0/ops/tables" : {
-      "get" : {
-        "summary" : "List the table names in the given keyspace",
-        "operationId" : "listTables",
-        "parameters" : [ {
-          "name" : "keyspaceName",
-          "in" : "query",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
+        },
+        "summary" : "Remove deleted data from one or more tables"
       }
     },
     "/api/v0/ops/tables/scrub" : {
       "post" : {
-        "summary" : "Scrub (rebuild sstables for) one or more tables",
         "operationId" : "scrub",
         "requestBody" : {
           "content" : {
@@ -876,21 +819,21 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Scrub (rebuild sstables for) one or more tables"
       }
     },
     "/api/v0/ops/tables/sstables/upgrade" : {
       "post" : {
-        "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
         "operationId" : "upgradeSSTables",
         "parameters" : [ {
-          "name" : "excludeCurrentVersion",
           "in" : "query",
+          "name" : "excludeCurrentVersion",
           "schema" : {
             "type" : "boolean"
           }
@@ -906,17 +849,73 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)"
+      }
+    },
+    "/api/v0/probes/cluster" : {
+      "get" : {
+        "operationId" : "checkClusterConsistency",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "consistency_level",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "in" : "query",
+          "name" : "rf_per_dc",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "content" : {
+              "*/*" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Indicated whether the Cassandra cluster is able to achieve the specified consistency"
+      }
+    },
+    "/api/v0/probes/liveness" : {
+      "get" : {
+        "operationId" : "checkLiveness",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Indicates whether this service is running"
+      }
+    },
+    "/api/v0/probes/readiness" : {
+      "get" : {
+        "operationId" : "checkReadiness",
+        "responses" : {
+          "default" : {
+            "content" : {
+              "text/plain" : { }
+            },
+            "description" : "default response"
+          }
+        },
+        "summary" : "Indicates whether the Cassandra service is ready to service requests"
       }
     },
     "/api/v1/ops/keyspace/cleanup" : {
       "post" : {
-        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
         "operationId" : "cleanup_v1",
         "requestBody" : {
           "content" : {
@@ -929,61 +928,118 @@
         },
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately"
       }
     },
     "/api/v1/ops/node/decommission" : {
       "post" : {
-        "summary" : "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.",
         "operationId" : "decommission_v1",
         "parameters" : [ {
-          "name" : "force",
           "in" : "query",
+          "name" : "force",
           "schema" : {
             "type" : "boolean"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id."
       }
     },
     "/api/v1/ops/node/rebuild" : {
       "post" : {
-        "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.",
         "operationId" : "rebuild_v1",
         "parameters" : [ {
-          "name" : "src_dc",
           "in" : "query",
+          "name" : "src_dc",
           "schema" : {
             "type" : "string"
           }
         } ],
         "responses" : {
           "default" : {
-            "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
+            },
+            "description" : "default response"
           }
-        }
+        },
+        "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id."
       }
     }
   },
   "components" : {
     "schemas" : {
+      "Column" : {
+        "type" : "object",
+        "properties" : {
+          "kind" : {
+            "type" : "string",
+            "enum" : [ "PARTITION_KEY", "CLUSTERING_COLUMN", "REGULAR", "STATIC" ]
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "order" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          },
+          "position" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "name", "type" ]
+      },
+      "CompactRequest" : {
+        "type" : "object",
+        "properties" : {
+          "end_token" : {
+            "type" : "string"
+          },
+          "keyspace_name" : {
+            "type" : "string"
+          },
+          "split_output" : {
+            "type" : "boolean"
+          },
+          "start_token" : {
+            "type" : "string"
+          },
+          "tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "user_defined" : {
+            "type" : "boolean"
+          },
+          "user_defined_files" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "keyspace_name", "split_output", "user_defined" ]
+      },
       "CreateOrAlterKeyspaceRequest" : {
-        "required" : [ "keyspace_name", "replication_settings" ],
         "type" : "object",
         "properties" : {
           "keyspace_name" : {
@@ -995,10 +1051,71 @@
               "$ref" : "#/components/schemas/ReplicationSetting"
             }
           }
-        }
+        },
+        "required" : [ "keyspace_name", "replication_settings" ]
+      },
+      "CreateTableRequest" : {
+        "type" : "object",
+        "properties" : {
+          "columns" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Column"
+            }
+          },
+          "keyspace_name" : {
+            "type" : "string"
+          },
+          "options" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object"
+            }
+          },
+          "table_name" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "columns", "keyspace_name", "table_name" ]
+      },
+      "KeyspaceRequest" : {
+        "type" : "object",
+        "properties" : {
+          "jobs" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "keyspace_name" : {
+            "type" : "string"
+          },
+          "tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "jobs", "keyspace_name", "tables" ]
+      },
+      "RepairRequest" : {
+        "type" : "object",
+        "properties" : {
+          "full" : {
+            "type" : "boolean"
+          },
+          "keyspace_name" : {
+            "type" : "string"
+          },
+          "tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "keyspace_name" ]
       },
       "ReplicationSetting" : {
-        "required" : [ "dc_name", "replication_factor" ],
         "type" : "object",
         "properties" : {
           "dc_name" : {
@@ -1008,12 +1125,18 @@
             "type" : "integer",
             "format" : "int32"
           }
-        }
+        },
+        "required" : [ "dc_name", "replication_factor" ]
       },
-      "KeyspaceRequest" : {
-        "required" : [ "jobs", "keyspace_name", "tables" ],
+      "ScrubRequest" : {
         "type" : "object",
         "properties" : {
+          "check_data" : {
+            "type" : "boolean"
+          },
+          "disable_snapshot" : {
+            "type" : "boolean"
+          },
           "jobs" : {
             "type" : "integer",
             "format" : "int32"
@@ -1021,37 +1144,29 @@
           "keyspace_name" : {
             "type" : "string"
           },
-          "tables" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }
-      },
-      "RepairRequest" : {
-        "required" : [ "keyspace_name" ],
-        "type" : "object",
-        "properties" : {
-          "keyspace_name" : {
-            "type" : "string"
-          },
-          "tables" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "full" : {
+          "reinsert_overflowed_ttl" : {
             "type" : "boolean"
+          },
+          "skip_corrupted" : {
+            "type" : "boolean"
+          },
+          "tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
           }
-        }
+        },
+        "required" : [ "check_data", "disable_snapshot", "jobs", "keyspace_name", "reinsert_overflowed_ttl", "skip_corrupted", "tables" ]
       },
       "TakeSnapshotRequest" : {
         "type" : "object",
         "properties" : {
-          "snapshot_name" : {
-            "type" : "string"
+          "keyspace_tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
           },
           "keyspaces" : {
             "type" : "array",
@@ -1059,133 +1174,18 @@
               "type" : "string"
             }
           },
-          "table_name" : {
-            "type" : "string"
-          },
           "skip_flsuh" : {
             "type" : "boolean",
             "writeOnly" : true
           },
-          "keyspace_tables" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
           "skip_flush" : {
             "type" : "boolean"
-          }
-        }
-      },
-      "CompactRequest" : {
-        "required" : [ "keyspace_name", "split_output", "user_defined" ],
-        "type" : "object",
-        "properties" : {
-          "split_output" : {
-            "type" : "boolean"
           },
-          "user_defined" : {
-            "type" : "boolean"
-          },
-          "start_token" : {
-            "type" : "string"
-          },
-          "end_token" : {
-            "type" : "string"
-          },
-          "keyspace_name" : {
-            "type" : "string"
-          },
-          "user_defined_files" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "tables" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }
-      },
-      "Column" : {
-        "required" : [ "name", "type" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string"
-          },
-          "kind" : {
-            "type" : "string",
-            "enum" : [ "PARTITION_KEY", "CLUSTERING_COLUMN", "REGULAR", "STATIC" ]
-          },
-          "position" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "order" : {
-            "type" : "string",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        }
-      },
-      "CreateTableRequest" : {
-        "required" : [ "columns", "keyspace_name", "table_name" ],
-        "type" : "object",
-        "properties" : {
-          "keyspace_name" : {
+          "snapshot_name" : {
             "type" : "string"
           },
           "table_name" : {
             "type" : "string"
-          },
-          "columns" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Column"
-            }
-          },
-          "options" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "object"
-            }
-          }
-        }
-      },
-      "ScrubRequest" : {
-        "required" : [ "check_data", "disable_snapshot", "jobs", "keyspace_name", "reinsert_overflowed_ttl", "skip_corrupted", "tables" ],
-        "type" : "object",
-        "properties" : {
-          "disable_snapshot" : {
-            "type" : "boolean"
-          },
-          "skip_corrupted" : {
-            "type" : "boolean"
-          },
-          "check_data" : {
-            "type" : "boolean"
-          },
-          "reinsert_overflowed_ttl" : {
-            "type" : "boolean"
-          },
-          "jobs" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "keyspace_name" : {
-            "type" : "string"
-          },
-          "tables" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
           }
         }
       }

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -107,6 +107,7 @@
     },
     "/api/v0/ops/executor/job" : {
       "get" : {
+        "summary" : "Returns Job deatils for the supplied Job ID",
         "operationId" : "getJobStatus",
         "parameters" : [ {
           "name" : "job_id",
@@ -127,6 +128,7 @@
     },
     "/api/v0/ops/seeds/reload" : {
       "post" : {
+        "summary" : "Reload the seed node list from the seed provider",
         "operationId" : "seedReload",
         "responses" : {
           "default" : {
@@ -141,7 +143,7 @@
     "/api/v0/ops/keyspace/alter" : {
       "post" : {
         "summary" : "Alter the replication settings of an existing keyspace",
-        "operationId" : "alter",
+        "operationId" : "alterKeyspace",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -187,7 +189,7 @@
     "/api/v0/ops/keyspace/create" : {
       "post" : {
         "summary" : "Create a new keyspace with the given name and replication settings",
-        "operationId" : "create",
+        "operationId" : "createKeyspace",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -210,7 +212,7 @@
     "/api/v0/ops/keyspace/replication" : {
       "get" : {
         "summary" : "Get the replication settings of an existing keyspace",
-        "operationId" : "getReplication",
+        "operationId" : "replication",
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
@@ -231,7 +233,7 @@
     "/api/v0/ops/keyspace" : {
       "get" : {
         "summary" : "List the keyspaces existing in the cluster",
-        "operationId" : "list",
+        "operationId" : "listKeyspaces",
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
@@ -752,7 +754,7 @@
     "/api/v0/ops/tables/create" : {
       "post" : {
         "summary" : "Create a new table",
-        "operationId" : "create_1",
+        "operationId" : "createTable",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -828,7 +830,7 @@
     "/api/v0/ops/tables" : {
       "get" : {
         "summary" : "List the table names in the given keyspace",
-        "operationId" : "list_1",
+        "operationId" : "listTables",
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
@@ -902,7 +904,7 @@
     "/api/v1/ops/keyspace/cleanup" : {
       "post" : {
         "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
-        "operationId" : "cleanup_1",
+        "operationId" : "cleanup_v1",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -925,7 +927,7 @@
     "/api/v1/ops/node/decommission" : {
       "post" : {
         "summary" : "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.",
-        "operationId" : "decommission_1",
+        "operationId" : "decommission_v1",
         "parameters" : [ {
           "name" : "force",
           "in" : "query",
@@ -946,7 +948,7 @@
     "/api/v1/ops/node/rebuild" : {
       "post" : {
         "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.",
-        "operationId" : "rebuild",
+        "operationId" : "rebuild_v1",
         "parameters" : [ {
           "name" : "src_dc",
           "in" : "query",

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -357,6 +357,11 @@
         } ],
         "responses" : {
           "200" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "OK"
+              }
+            },
             "description" : "Role created"
           },
           "400" : {
@@ -392,6 +397,16 @@
               }
             },
             "description" : "Map of job details"
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Job"
+                }
+              }
+            },
+            "description" : "Job not found"
           }
         },
         "summary" : "Returns Job deatils for the supplied Job ID"

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -49,34 +49,6 @@
         }
       }
     },
-    "/api/v0/probes/liveness" : {
-      "get" : {
-        "summary" : "Indicates whether this service is running",
-        "operationId" : "checkLiveness",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/probes/readiness" : {
-      "get" : {
-        "summary" : "Indicates whether the Cassandra service is ready to service requests",
-        "operationId" : "checkReadiness",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
     "/api/v0/probes/cluster" : {
       "get" : {
         "summary" : "Indicated whether the Cassandra cluster is able to achieve the specified consistency",
@@ -105,6 +77,54 @@
         }
       }
     },
+    "/api/v0/probes/liveness" : {
+      "get" : {
+        "summary" : "Indicates whether this service is running",
+        "operationId" : "checkLiveness",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/probes/readiness" : {
+      "get" : {
+        "summary" : "Indicates whether the Cassandra service is ready to service requests",
+        "operationId" : "checkReadiness",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/executor/job" : {
+      "get" : {
+        "operationId" : "getJobStatus",
+        "parameters" : [ {
+          "name" : "job_id",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "*/*" : { }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/ops/seeds/reload" : {
       "post" : {
         "operationId" : "seedReload",
@@ -118,36 +138,79 @@
         }
       }
     },
-    "/api/v0/ops/executor/job" : {
-      "get" : {
-        "summary" : "Returns the JobDetails",
-        "operationId" : "getJobStatus",
-        "parameters": [{
-          "name": "job_id",
-          "in": "query",
-          "required": true,
-          "schema": {
-            "type": "string"
+    "/api/v0/ops/keyspace/alter" : {
+      "post" : {
+        "summary" : "Alter the replication settings of an existing keyspace",
+        "operationId" : "alter",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrAlterKeyspaceRequest"
+              }
+            }
           }
-        }],
+        },
         "responses" : {
           "default" : {
-            "description" : "details of Job matching job_id",
+            "description" : "default response",
             "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Job"
-                }
-              }
+              "text/plain" : { }
             }
           }
         }
       }
     },
-    "/api/v0/ops/keyspace" : {
+    "/api/v0/ops/keyspace/cleanup" : {
+      "post" : {
+        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.",
+        "operationId" : "cleanup",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/KeyspaceRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/keyspace/create" : {
+      "post" : {
+        "summary" : "Create a new keyspace with the given name and replication settings",
+        "operationId" : "create",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/CreateOrAlterKeyspaceRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/keyspace/replication" : {
       "get" : {
-        "summary" : "List the keyspaces existing in the cluster",
-        "operationId" : "listKeyspaces",
+        "summary" : "Get the replication settings of an existing keyspace",
+        "operationId" : "getReplication",
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
@@ -165,13 +228,12 @@
         }
       }
     },
-    "/api/v0/ops/keyspace/replication" : {
+    "/api/v0/ops/keyspace" : {
       "get" : {
-        "summary" : "Get the replication settings of an existing keyspace",
-        "operationId" : "replication",
+        "summary" : "List the keyspaces existing in the cluster",
+        "operationId" : "list",
         "parameters" : [ {
           "name" : "keyspaceName",
-          "required": true,
           "in" : "query",
           "schema" : {
             "type" : "string"
@@ -181,31 +243,7 @@
           "default" : {
             "description" : "default response",
             "content" : {
-              "application/json" : {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                "examples": {
-                  "NetworkTopologyStrategy": {
-                    "value": {
-                      "class": "org.apache.cassandra.locator.NetworkTopologyStrategy",
-                      "dc1": "3",
-                      "dc2": "1"
-                    },
-                    "summary": "Example for a keyspace with NetworkTopologyStrategy"
-                  },
-                  "SimpleStrategy": {
-                    "value": {
-                      "class": "org.apache.cassandra.locator.SimpleStrategy",
-                      "replication_factor": "3"
-                    },
-                    "summary": "Example for a keyspace with SimpleStrategy"
-                  }
-                }
-              }
+              "application/json" : { }
             }
           }
         }
@@ -238,15 +276,22 @@
         }
       }
     },
-    "/api/v0/ops/keyspace/alter" : {
+    "/api/v0/lifecycle/configure" : {
       "post" : {
-        "summary" : "Alter the replication settings of an existing keyspace",
-        "operationId" : "alterKeyspace",
+        "description" : "Configure Cassandra. Will fail if Cassandra is already started",
+        "operationId" : "configureNodeJson",
+        "parameters" : [ {
+          "name" : "profile",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreateOrAlterKeyspaceRequest"
+                "type" : "string"
               }
             }
           }
@@ -255,77 +300,21 @@
           "default" : {
             "description" : "default response",
             "content" : {
-              "text/plain" : { }
+              "*/*" : { }
             }
           }
         }
       }
     },
-    "/api/v0/ops/keyspace/create" : {
-      "post" : {
-        "summary" : "Create a new keyspace with the given name and replication settings",
-        "operationId" : "createKeyspace",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateOrAlterKeyspaceRequest"
-              }
-            }
-          }
-        },
+    "/api/v0/lifecycle/pid" : {
+      "get" : {
+        "description" : "The PID of Cassandra/DSE, if it's running",
+        "operationId" : "getPID",
         "responses" : {
           "default" : {
             "description" : "default response",
             "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/keyspace/cleanup" : {
-      "post" : {
-        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and waits for the cleanup to finish.",
-        "operationId" : "cleanup",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/KeyspaceRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/ops/keyspace/cleanup" : {
-      "post" : {
-        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
-        "operationId" : "cleanup",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/KeyspaceRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
+              "*/*" : { }
             }
           }
         }
@@ -372,59 +361,15 @@
         }
       }
     },
-    "/api/v0/lifecycle/configure" : {
-      "post" : {
-        "description" : "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started",
-        "operationId" : "configureNode",
-        "parameters" : [ {
-          "name" : "profile",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/yaml" : {
-              "schema" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "*/*" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/lifecycle/pid" : {
+    "/api/v0/metadata/endpoints" : {
       "get" : {
-        "description" : "The PID of Cassandra/DSE, if it's running",
-        "operationId" : "getPID",
+        "summary" : "Returns this nodes view of the endpoint states of nodes",
+        "operationId" : "getEndpointStates",
         "responses" : {
           "default" : {
             "description" : "default response",
             "content" : {
-              "*/*" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/versions/release" : {
-      "get" : {
-        "summary" : "Returns the Cassandra release version",
-        "operationId" : "getReleaseVersion",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
+              "application/json" : { }
             }
           }
         }
@@ -434,24 +379,6 @@
       "get" : {
         "summary" : "Returns the management-api featureSet",
         "operationId" : "getFeatureSet",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/FeatureSet"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/metadata/endpoints" : {
-      "get" : {
-        "summary" : "Returns this nodes view of the endpoint states of nodes",
-        "operationId" : "getEndpointStates",
         "responses" : {
           "default" : {
             "description" : "default response",
@@ -476,10 +403,10 @@
         }
       }
     },
-    "/api/v0/ops/node/drain" : {
-      "post" : {
-        "summary" : "Drain the node (stop accepting writes and flush all tables)",
-        "operationId" : "drain",
+    "/api/v0/metadata/versions/release" : {
+      "get" : {
+        "summary" : "Returns the Cassandra release version",
+        "operationId" : "getReleaseVersion",
         "responses" : {
           "default" : {
             "description" : "default response",
@@ -490,15 +417,15 @@
         }
       }
     },
-    "/api/v0/ops/node/fullquerylogging" : {
+    "/api/v0/ops/node/assassinate" : {
       "post" : {
-        "summary" : "Enable or disable full query logging facility.",
-        "operationId" : "setFullQuerylog",
+        "summary" : "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode",
+        "operationId" : "assassinate",
         "parameters" : [ {
-          "name" : "enabled",
+          "name" : "address",
           "in" : "query",
           "schema" : {
-            "type" : "boolean"
+            "type" : "string"
           }
         } ],
         "responses" : {
@@ -509,10 +436,83 @@
             }
           }
         }
-      },
+      }
+    },
+    "/api/v0/ops/node/snapshots" : {
       "get" : {
-        "summary" : "Get whether full query logging is enabled.",
-        "operationId" : "isFullQueryLogEnabled",
+        "summary" : "Retrieve snapshot details",
+        "operationId" : "getSnapshotDetails",
+        "parameters" : [ {
+          "name" : "snapshotNames",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "keyspaces",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      },
+      "post" : {
+        "summary" : "Take a snapshot",
+        "operationId" : "takeSnapshot",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TakeSnapshotRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Clear snapshots",
+        "operationId" : "clearSnapshots",
+        "parameters" : [ {
+          "name" : "snapshotNames",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "keyspaces",
+          "in" : "query",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
         "responses" : {
           "default" : {
             "description" : "default response",
@@ -544,17 +544,108 @@
         }
       }
     },
-    "/api/v1/ops/node/decommission" : {
+    "/api/v0/ops/node/drain" : {
       "post" : {
-        "summary" : "Decommission the *node I am connecting to*. This method returns immediately and returns a job id.",
-        "operationId" : "decommission",
+        "summary" : "Drain the node (stop accepting writes and flush all tables)",
+        "operationId" : "drain",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/node/streaminfo" : {
+      "get" : {
+        "summary" : "Retrieve Streaming status information",
+        "operationId" : "getStreamInfo",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/node/fullquerylogging" : {
+      "get" : {
+        "summary" : "Get whether full query logging is enabled.",
+        "operationId" : "isFullQueryLogEnabled",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      },
+      "post" : {
+        "summary" : "Enable or disable full query logging facility.",
+        "operationId" : "setFullQuerylog",
         "parameters" : [ {
-          "name" : "force",
+          "name" : "enabled",
           "in" : "query",
           "schema" : {
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/node/schema/reload" : {
+      "post" : {
+        "summary" : "Reload local node schema from system tables",
+        "operationId" : "reloadLocalSchema",
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/node/repair" : {
+      "post" : {
+        "summary" : "Perform a nodetool repair",
+        "operationId" : "repair",
+        "requestBody" : {
+          "content" : {
+            "*/*" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/RepairRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ops/node/schema/reset" : {
+      "post" : {
+        "summary" : "Reset node's local schema and resync",
+        "operationId" : "resetLocalSchema",
         "responses" : {
           "default" : {
             "description" : "default response",
@@ -575,27 +666,6 @@
           "schema" : {
             "type" : "integer",
             "format" : "int32"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/assassinate" : {
-      "post" : {
-        "summary" : "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode",
-        "operationId" : "assassinate",
-        "parameters" : [ {
-          "name" : "address",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
           }
         } ],
         "responses" : {
@@ -656,119 +726,15 @@
         }
       }
     },
-    "/api/v0/ops/node/schema/reset" : {
+    "/api/v0/ops/tables/compact" : {
       "post" : {
-        "summary" : "Reset node's local schema and resync",
-        "operationId" : "resetLocalSchema",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/schema/reload" : {
-      "post" : {
-        "summary" : "Reload local node schema from system tables",
-        "operationId" : "reloadLocalSchema",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/streaminfo" : {
-      "get" : {
-        "summary" : "Retrieve Streaming status information",
-        "operationId" : "getStreamInfo",
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/snapshots" : {
-      "get" : {
-        "summary" : "Retrieve snapshot details",
-        "operationId" : "getSnapshotDetails",
-        "parameters" : [ {
-          "name" : "snapshotNames",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "keyspaces",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        }
-      },
-      "delete" : {
-        "summary" : "Clear snapshots",
-        "operationId" : "clearSnapshots",
-        "parameters" : [ {
-          "name" : "snapshotNames",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "keyspaces",
-          "in" : "query",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      },
-      "post" : {
-        "summary" : "Take a snapshot",
-        "operationId" : "takeSnapshot",
+        "summary" : "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables",
+        "operationId" : "compact",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/TakeSnapshotRequest"
+                "$ref" : "#/components/schemas/CompactRequest"
               }
             }
           }
@@ -778,59 +744,6 @@
             "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/node/repair" : {
-      "post" : {
-        "summary" : "Execute a nodetool repair operation",
-        "operationId" : "repair",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/RepairRequest"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/ops/tables" : {
-      "get" : {
-        "summary" : "List the tables in a keyspace",
-        "operationId" : "listTables",
-        "parameters" : [ {
-          "name" : "keyspaceName",
-          "required": true,
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "application/json" : {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "example": [ "table1", "table2" ]
-              }
             }
           }
         }
@@ -838,30 +751,13 @@
     },
     "/api/v0/ops/tables/create" : {
       "post" : {
-        "summary" : "Create a new table in an existing keyspace",
-        "operationId" : "createTable",
+        "summary" : "Create a new table",
+        "operationId" : "create_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
                 "$ref" : "#/components/schemas/CreateTableRequest"
-              },
-              "example": {
-                "keyspace_name" : "ks1",
-                "table_name" : "table1",
-                "columns" : [
-                  { "name" : "pk1", "type": "int", "kind" : "PARTITION_KEY", "position" : 0 },
-                  { "name" : "pk2", "type": "int", "kind" : "PARTITION_KEY", "position" : 1 },
-                  { "name" : "cc1", "type": "timeuuid", "kind" : "CLUSTERING", "position" : 0, "order" : "DESC" },
-                  { "name" : "cc2", "type": "text", "kind" : "CLUSTERING", "position" : 1, "order" : "ASC" },
-                  { "name" : "v1", "type": "timestamp", "kind" : "REGULAR" },
-                  { "name" : "v2", "type": "list<text>", "kind" : "REGULAR" },
-                  { "name" : "s", "type": "boolean", "kind" : "STATIC" }
-                ],
-                "options": {
-                  "bloom_filter_fp_chance": "0.01",
-                  "caching" : { "keys": "ALL", "rows_per_partition" : "NONE" }
-                }
               }
             }
           }
@@ -876,17 +772,10 @@
         }
       }
     },
-    "/api/v0/ops/tables/sstables/upgrade" : {
+    "/api/v0/ops/tables/flush" : {
       "post" : {
-        "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
-        "operationId" : "upgradeSSTables",
-        "parameters" : [ {
-          "name" : "excludeCurrentVersion",
-          "in" : "query",
-          "schema" : {
-            "type" : "boolean"
-          }
-        } ],
+        "summary" : "Flush one or more tables",
+        "operationId" : "flush",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -936,6 +825,27 @@
         }
       }
     },
+    "/api/v0/ops/tables" : {
+      "get" : {
+        "summary" : "List the table names in the given keyspace",
+        "operationId" : "list_1",
+        "parameters" : [ {
+          "name" : "keyspaceName",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "application/json" : { }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/ops/tables/scrub" : {
       "post" : {
         "summary" : "Scrub (rebuild sstables for) one or more tables",
@@ -959,10 +869,17 @@
         }
       }
     },
-    "/api/v0/ops/tables/flush" : {
+    "/api/v0/ops/tables/sstables/upgrade" : {
       "post" : {
-        "summary" : "Flush one or more tables",
-        "operationId" : "flush",
+        "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
+        "operationId" : "upgradeSSTables",
+        "parameters" : [ {
+          "name" : "excludeCurrentVersion",
+          "in" : "query",
+          "schema" : {
+            "type" : "boolean"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -982,19 +899,61 @@
         }
       }
     },
-    "/api/v0/ops/tables/compact" : {
+    "/api/v1/ops/keyspace/cleanup" : {
       "post" : {
-        "summary" : "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables",
-        "operationId" : "compact",
+        "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
+        "operationId" : "cleanup_1",
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CompactRequest"
+                "$ref" : "#/components/schemas/KeyspaceRequest"
               }
             }
           }
         },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ops/node/decommission" : {
+      "post" : {
+        "summary" : "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.",
+        "operationId" : "decommission_1",
+        "parameters" : [ {
+          "name" : "force",
+          "in" : "query",
+          "schema" : {
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "text/plain" : { }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/ops/node/rebuild" : {
+      "post" : {
+        "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.",
+        "operationId" : "rebuild",
+        "parameters" : [ {
+          "name" : "src_dc",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "responses" : {
           "default" : {
             "description" : "default response",
@@ -1055,26 +1014,10 @@
           }
         }
       },
-      "ScrubRequest" : {
-        "required" : [ "check_data", "disable_snapshot", "jobs", "keyspace_name", "reinsert_overflowed_ttl", "skip_corrupted", "tables" ],
+      "RepairRequest" : {
+        "required" : [ "keyspace_name" ],
         "type" : "object",
         "properties" : {
-          "disable_snapshot" : {
-            "type" : "boolean"
-          },
-          "skip_corrupted" : {
-            "type" : "boolean"
-          },
-          "check_data" : {
-            "type" : "boolean"
-          },
-          "reinsert_overflowed_ttl" : {
-            "type" : "boolean"
-          },
-          "jobs" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
           "keyspace_name" : {
             "type" : "string"
           },
@@ -1083,6 +1026,39 @@
             "items" : {
               "type" : "string"
             }
+          },
+          "full" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "TakeSnapshotRequest" : {
+        "type" : "object",
+        "properties" : {
+          "snapshot_name" : {
+            "type" : "string"
+          },
+          "keyspaces" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "table_name" : {
+            "type" : "string"
+          },
+          "skip_flsuh" : {
+            "type" : "boolean",
+            "writeOnly" : true
+          },
+          "keyspace_tables" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "skip_flush" : {
+            "type" : "boolean"
           }
         }
       },
@@ -1119,37 +1095,74 @@
           }
         }
       },
-      "TakeSnapshotRequest" : {
-        "required" : [ ],
+      "Column" : {
+        "required" : [ "name", "type" ],
         "type" : "object",
         "properties" : {
-          "snapshot_name" : {
+          "name" : {
             "type" : "string"
           },
-          "keyspaces" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
+          "type" : {
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string",
+            "enum" : [ "PARTITION_KEY", "CLUSTERING_COLUMN", "REGULAR", "STATIC" ]
+          },
+          "position" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "order" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        }
+      },
+      "CreateTableRequest" : {
+        "required" : [ "columns", "keyspace_name", "table_name" ],
+        "type" : "object",
+        "properties" : {
+          "keyspace_name" : {
+            "type" : "string"
           },
           "table_name" : {
             "type" : "string"
           },
-          "skip_flush" : {
-            "type" : "boolean"
-          },
-          "keyspace_tables" : {
+          "columns" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "$ref" : "#/components/schemas/Column"
+            }
+          },
+          "options" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object"
             }
           }
         }
       },
-      "RepairRequest" : {
-        "required" : [ "keyspace_name" ],
+      "ScrubRequest" : {
+        "required" : [ "check_data", "disable_snapshot", "jobs", "keyspace_name", "reinsert_overflowed_ttl", "skip_corrupted", "tables" ],
         "type" : "object",
         "properties" : {
+          "disable_snapshot" : {
+            "type" : "boolean"
+          },
+          "skip_corrupted" : {
+            "type" : "boolean"
+          },
+          "check_data" : {
+            "type" : "boolean"
+          },
+          "reinsert_overflowed_ttl" : {
+            "type" : "boolean"
+          },
+          "jobs" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
           "keyspace_name" : {
             "type" : "string"
           },
@@ -1158,145 +1171,6 @@
             "items" : {
               "type" : "string"
             }
-          },
-          "full" : {
-            "type" : "boolean"
-          }
-        }
-      },
-      "CreateTableRequest": {
-        "type": "object",
-        "required": [
-          "keyspace_name",
-          "table_name",
-          "columns"
-        ],
-        "properties": {
-          "keyspace_name": {
-            "type": "string",
-            "description": "The name of the keyspace where the table is to be created. The keyspace must exist."
-          },
-          "table_name": {
-            "type": "string",
-            "description": "The name of the table to create."
-          },
-          "columns": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "name",
-                "type",
-                "kind"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "The name of the column."
-                },
-                "type": {
-                  "type": "string",
-                  "description": "The type of the column. Must be a valid CQL type, e.g. text, int or list<timmeuid>."
-                },
-                "kind": {
-                  "type": "string",
-                  "description": "The kind of the column. Must be one of: PARTITION_KEY, CLUSTERING_COLUMN, REGULAR, STATIC.",
-                  "enum": [
-                    "PARTITION_KEY",
-                    "CLUSTERING_COLUMN",
-                    "REGULAR",
-                    "STATIC"
-                  ]
-                },
-                "position": {
-                  "type": "integer",
-                  "description": "The zero-based index of the column in the partition key or clustering column group. Only required for the PARTITION_KEY and CLUSTERING_COLUMN kinds, ignored otherwise. Must be equal to or greater than zero.",
-                  "minimum": 0
-                },
-                "order": {
-                  "type": "string",
-                  "description": "The clustering order of the column. Only required for the CLUSTERING_COLUMN kind, ignored otherwise. Must be one of: ASC, DESC.",
-                  "enum": [
-                    "ASC",
-                    "DESC"
-                  ]
-                }
-              }
-            }
-          },
-          "options": {
-            "description": "The table options. Each option value must be either a string or a dictionary of strings.",
-            "oneOf": [
-              {
-                "type": "object",
-                "example": {
-                  "bloom_filter_fp_chance": "0.01"
-                },
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "object",
-                "example": {
-                  "caching": {
-                    "keys": "ALL",
-                    "rows_per_partition": "NONE"
-                  }
-                },
-                "additionalProperties": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          }
-        }
-      },
-      "FeatureSet": {
-        "type": "object",
-        "properties": {
-          "cassandra_version": {
-            "type": "string"
-          },
-          "mgmt_version": {
-            "type": "string"
-          },
-          "features" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }
-      },
-      "Job": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "WAITING",
-              "COMPLETED",
-              "ERROR"
-            ]
-          },
-          "submit_time": {
-            "type": "string"
-          },
-          "end_time": {
-            "type": "string"
-          },
-          "error": {
-            "type": "string"
           }
         }
       }

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -292,13 +292,8 @@
           "200" : {
             "content" : {
               "application/json" : {
-                "example" : {
-                  "cassandra_version" : "4.0.1",
-                  "mgmt_version" : "",
-                  "features" : [ "async_sstable_tasks", "full_query_logging", "rebuild" ]
-                },
                 "schema" : {
-                  "type" : "string"
+                  "$ref" : "#/components/schemas/FeatureSet"
                 }
               }
             },
@@ -1612,6 +1607,24 @@
           }
         },
         "required" : [ "columns", "keyspace_name", "table_name" ]
+      },
+      "FeatureSet" : {
+        "type" : "object",
+        "properties" : {
+          "cassandra_version" : {
+            "type" : "string"
+          },
+          "features" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "ASYNC_SSTABLE_TASKS", "FULL_QUERY_LOGGING", "REBUILD" ]
+            }
+          },
+          "mgmt_version" : {
+            "type" : "string"
+          }
+        }
       },
       "Job" : {
         "type" : "object",

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -41,11 +41,41 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "*/*" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra configured successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "config missing",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Cassandra configure request is missing required data or has invalid data"
+          },
+          "406" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Cassandra is running, try /api/v0/lifecycle/stop first",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Cassandra can't be configured while running"
+          },
+          "500" : {
+            "description" : "Error configuring Cassandra"
           }
         }
       }
@@ -55,11 +85,30 @@
         "description" : "The PID of Cassandra/DSE, if it's running",
         "operationId" : "getPID",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "*/*" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra Process ID"
+          },
+          "204" : {
+            "description" : "No Cassandra Process running"
+          },
+          "500" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "error message",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Error finding Cassandra Process"
           }
         }
       }
@@ -82,11 +131,47 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "201" : {
             "content" : {
-              "*/*" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra started successfully"
+          },
+          "202" : {
+            "description" : "Cassandra already running and can connect"
+          },
+          "204" : {
+            "description" : "Cassandra already running but can't connect"
+          },
+          "206" : {
+            "description" : "Cassandra process not found but can connect"
+          },
+          "420" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Error starting Cassandra",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Cassandra could not start successfully"
+          },
+          "500" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "error message",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Error trying to start Cassandra"
           }
         }
       }
@@ -96,11 +181,27 @@
         "description" : "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called",
         "operationId" : "stopNode",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "*/*" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra stopped successfully"
+          },
+          "500" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Killing Cassandra Failed",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Cassandra not stopped successfully"
           }
         }
       }
@@ -109,11 +210,57 @@
       "get" : {
         "operationId" : "getEndpointStates",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "entity" : [ {
+                    "DC" : "datacenter1",
+                    "ENDPOINT_IP" : "172.17.0.2",
+                    "HOST_ID" : "5d2318b0-cfec-4697-8ed2-014b5f434ae8",
+                    "IS_ALIVE" : "true",
+                    "LOAD" : "135527.0",
+                    "NATIVE_ADDRESS_AND_PORT" : "172.17.0.2:9042",
+                    "NET_VERSION" : "12",
+                    "RACK" : "rack1",
+                    "RELEASE_VERSION" : "4.0.1",
+                    "RPC_ADDRESS" : "172.17.0.2",
+                    "RPC_READY" : "true",
+                    "SCHEMA" : "2207c2a9-f598-3971-986b-2926e09e239d",
+                    "SSTABLE_VERSIONS" : "big-nb",
+                    "STATUS" : "NORMAL,-2444908528344618126",
+                    "STATUS_WITH_PORT" : "NORMAL,-2444908528344618126",
+                    "TOKENS" : "<tokens>"
+                  } ],
+                  "variant" : {
+                    "language" : null,
+                    "mediaType" : {
+                      "type" : "application",
+                      "subtype" : "json",
+                      "parameters" : { },
+                      "wildcardType" : false,
+                      "wildcardSubtype" : false
+                    },
+                    "encoding" : null,
+                    "languageString" : null
+                  },
+                  "annotations" : [ ],
+                  "mediaType" : {
+                    "type" : "application",
+                    "subtype" : "json",
+                    "parameters" : { },
+                    "wildcardType" : false,
+                    "wildcardSubtype" : false
+                  },
+                  "language" : null,
+                  "encoding" : null
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Endpoint states'"
           }
         },
         "summary" : "Returns this nodes view of the endpoint states of nodes"
@@ -123,11 +270,16 @@
       "get" : {
         "operationId" : "getLocalDataCenter",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "datacenter1",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Local datacenter'"
           }
         },
         "summary" : "Returns the DataCenter the local node belongs to"
@@ -137,11 +289,20 @@
       "get" : {
         "operationId" : "getFeatureSet",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "cassandra_version" : "4.0.1",
+                  "mgmt_version" : "",
+                  "features" : [ "async_sstable_tasks", "full_query_logging", "rebuild" ]
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Local datacenter'"
           }
         },
         "summary" : "Returns the management-api featureSet"
@@ -151,11 +312,16 @@
       "get" : {
         "operationId" : "getReleaseVersion",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "4.0.1",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra version'"
           }
         },
         "summary" : "Returns the Cassandra release version"
@@ -190,11 +356,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
+            "description" : "Role created"
+          },
+          "400" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "Username is empty"
+              }
             },
-            "description" : "default response"
+            "description" : "Username and/or password is empty"
           }
         },
         "summary" : "Creates a new user role"
@@ -212,11 +383,15 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "*/*" : { }
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Job"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Map of job details"
           }
         },
         "summary" : "Returns Job deatils for the supplied Job ID"
@@ -233,11 +408,13 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : [ "system_schema", "system", "system_auth", "system_distributed", "system_traces" ]
+              }
             },
-            "description" : "default response"
+            "description" : "List of Keyspaces"
           }
         },
         "summary" : "List the keyspaces existing in the cluster"
@@ -256,11 +433,21 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Keyspace Replication Settings altered successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Altering Keyspace failed. Non-empty 'keyspace_name' must be provided"
+              }
+            },
+            "description" : "Keyspace name or Replication Settings not provided"
           }
         },
         "summary" : "Alter the replication settings of an existing keyspace"
@@ -279,11 +466,16 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "d69d1d95-9348-4460-95d2-ae342870fade",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Job ID for keyspace cleanup process"
           }
         },
         "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing."
@@ -302,11 +494,21 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Keyspace created successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Keyspace creation failed. Non-empty 'keyspace_name' must be provided"
+              }
+            },
+            "description" : "Keyspace name or Replication Settings not provided"
           }
         },
         "summary" : "Create a new keyspace with the given name and replication settings"
@@ -329,11 +531,21 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "SSTables loaded successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Must provide a keyspace name"
+              }
+            },
+            "description" : "Keyspace name or Table name not provided"
           }
         },
         "summary" : "Load newly placed SSTables to the system without restart"
@@ -351,11 +563,32 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "class" : "org.apache.cassandra.locator.SimpleStrategy",
+                  "replication_factor" : "2"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Keyspace Replication Settings"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Get keyspace replication failed. Non-empty 'keyspaceName' must be provided"
+              }
+            },
+            "description" : "Keyspace name not provided"
+          },
+          "404" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Get keyspace replication failed. Keyspace 'my_keyspace' does not exist."
+              }
+            },
+            "description" : "Keyspace name not found"
           }
         },
         "summary" : "Get the replication settings of an existing keyspace"
@@ -372,11 +605,27 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node assasinated successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Address must be provided",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Cassandra node assasination request missing address"
           }
         },
         "summary" : "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode"
@@ -394,11 +643,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra compaction throughput set successfully"
           }
         },
         "summary" : "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling"
@@ -415,11 +669,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node decommissioned successfully"
           }
         },
         "summary" : "Decommission the *node I am connecting to*"
@@ -429,11 +688,16 @@
       "post" : {
         "operationId" : "drain",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node drained successfully"
           }
         },
         "summary" : "Drain the node (stop accepting writes and flush all tables)"
@@ -443,11 +707,40 @@
       "get" : {
         "operationId" : "isFullQueryLogEnabled",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "entity" : false,
+                  "variant" : {
+                    "language" : null,
+                    "mediaType" : {
+                      "type" : "application",
+                      "subtype" : "json",
+                      "parameters" : { },
+                      "wildcardType" : false,
+                      "wildcardSubtype" : false
+                    },
+                    "encoding" : null,
+                    "languageString" : null
+                  },
+                  "annotations" : [ ],
+                  "mediaType" : {
+                    "type" : "application",
+                    "subtype" : "json",
+                    "parameters" : { },
+                    "wildcardType" : false,
+                    "wildcardSubtype" : false
+                  },
+                  "language" : null,
+                  "encoding" : null
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Full Query enabled"
           }
         },
         "summary" : "Get whether full query logging is enabled."
@@ -462,11 +755,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Full Query Logging set successfully"
           }
         },
         "summary" : "Enable or disable full query logging facility."
@@ -483,11 +781,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node hints truncated successfully"
           }
         },
         "summary" : "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified."
@@ -510,11 +813,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra logging level set successfully"
           }
         },
         "summary" : "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters."
@@ -533,11 +841,27 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Nodetool repair executed successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "keyspaceName must be specified",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Repair request missing Keyspace name"
           }
         },
         "summary" : "Execute a nodetool repair operation"
@@ -547,11 +871,16 @@
       "post" : {
         "operationId" : "reloadLocalSchema",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node schema reloaded successfully"
           }
         },
         "summary" : "Reload local node schema from system tables"
@@ -561,11 +890,16 @@
       "post" : {
         "operationId" : "resetLocalSchema",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra node scheam resynced successfully"
           }
         },
         "summary" : "Reset node's local schema and resync"
@@ -594,11 +928,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Snapshots cleared successfully"
           }
         },
         "summary" : "Clear snapshots"
@@ -625,11 +964,52 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "entity" : [ {
+                    "Column family name" : "size_estimates",
+                    "Keyspace name" : "system",
+                    "Size on disk" : "13 bytes",
+                    "Snapshot name" : "truncated-1639687082845-size_estimates",
+                    "True size" : "0 bytes"
+                  }, {
+                    "Column family name" : "table_estimates",
+                    "Keyspace name" : "system",
+                    "Size on disk" : "13 bytes",
+                    "Snapshot name" : "truncated-1639687082982-table_estimates",
+                    "True size" : "0 bytes"
+                  } ],
+                  "variant" : {
+                    "language" : null,
+                    "mediaType" : {
+                      "type" : "application",
+                      "subtype" : "json",
+                      "parameters" : { },
+                      "wildcardType" : false,
+                      "wildcardSubtype" : false
+                    },
+                    "encoding" : null,
+                    "languageString" : null
+                  },
+                  "annotations" : [ ],
+                  "mediaType" : {
+                    "type" : "application",
+                    "subtype" : "json",
+                    "parameters" : { },
+                    "wildcardType" : false,
+                    "wildcardSubtype" : false
+                  },
+                  "language" : null,
+                  "encoding" : null
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra snapshot details"
           }
         },
         "summary" : "Retrieve snapshot details"
@@ -646,11 +1026,27 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Snapshot created successfully"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "When specifying keyspace_tables, specifying keyspaces is not allowed",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Invalid snapshot request"
           }
         },
         "summary" : "Take a snapshot"
@@ -660,11 +1056,40 @@
       "get" : {
         "operationId" : "getStreamInfo",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : {
+                  "entity" : [ ],
+                  "variant" : {
+                    "language" : null,
+                    "mediaType" : {
+                      "type" : "application",
+                      "subtype" : "json",
+                      "parameters" : { },
+                      "wildcardType" : false,
+                      "wildcardSubtype" : false
+                    },
+                    "encoding" : null,
+                    "languageString" : null
+                  },
+                  "annotations" : [ ],
+                  "mediaType" : {
+                    "type" : "application",
+                    "subtype" : "json",
+                    "parameters" : { },
+                    "wildcardType" : false,
+                    "wildcardSubtype" : false
+                  },
+                  "language" : null,
+                  "encoding" : null
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra streaming status info"
           }
         },
         "summary" : "Retrieve Streaming status information"
@@ -674,11 +1099,16 @@
       "post" : {
         "operationId" : "seedReload",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "*/*" : { }
+              "application/json" : {
+                "example" : "[127.0.0.1, 127.0.0.2]",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "List of new seeds after reload"
           }
         },
         "summary" : "Reload the seed node list from the seed provider"
@@ -696,11 +1126,21 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "example" : [ "table_1", "table_2" ]
+              }
             },
-            "description" : "default response"
+            "description" : "Table list"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "List tables failed. Non-empty 'keyspaceName' must be provided"
+              }
+            },
+            "description" : "Keyspace name not provided"
           }
         },
         "summary" : "List the table names in the given keyspace"
@@ -719,11 +1159,21 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Table compaction successful"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Invalid option combination: Can not use split-output here"
+              }
+            },
+            "description" : "Invalid table compaction request"
           }
         },
         "summary" : "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables"
@@ -742,11 +1192,21 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Table creation successful"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Table creation failed: some failure message"
+              }
+            },
+            "description" : "Table creation failed"
           }
         },
         "summary" : "Create a new table in an existing keyspace"
@@ -765,11 +1225,13 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Table flush successful"
           }
         },
         "summary" : "Flush one or more tables"
@@ -795,11 +1257,21 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Table garbage collection successful"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "tombstoneOption must be either ROW or CELL"
+              }
+            },
+            "description" : "Invalid table garbage collection request"
           }
         },
         "summary" : "Remove deleted data from one or more tables"
@@ -818,11 +1290,13 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Table scrub successful"
           }
         },
         "summary" : "Scrub (rebuild sstables for) one or more tables"
@@ -848,11 +1322,13 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "SSTable upgrade successful"
           }
         },
         "summary" : "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)"
@@ -876,11 +1352,22 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "200" : {
+            "description" : "Cassandra is able to achieve the specified consistency"
+          },
+          "500" : {
             "content" : {
-              "*/*" : { }
+              "application/json" : {
+                "example" : {
+                  "[-8842966077830801609, -7599446072150209635]" : [ "2 replicas required, but only 1 nodes in the ring" ],
+                  "[-7599446072150209635, -6632081829071674136]" : [ "2 replicas required, but only 1 nodes in the ring" ]
+                },
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cassandra is unable to achieve the specified consistency"
           }
         },
         "summary" : "Indicated whether the Cassandra cluster is able to achieve the specified consistency"
@@ -890,11 +1377,13 @@
       "get" : {
         "operationId" : "checkLiveness",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Service is running"
           }
         },
         "summary" : "Indicates whether this service is running"
@@ -904,11 +1393,16 @@
       "get" : {
         "operationId" : "checkReadiness",
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK"
+              }
             },
-            "description" : "default response"
+            "description" : "Service is ready to handle requests"
+          },
+          "500" : {
+            "description" : "Service is not ready to handle requests"
           }
         },
         "summary" : "Indicates whether the Cassandra service is ready to service requests"
@@ -927,11 +1421,27 @@
           }
         },
         "responses" : {
-          "default" : {
+          "200" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "OK",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Cleanup not needed for tables 'system' or 'system_schema'"
+          },
+          "202" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "d69d1d95-9348-4460-95d2-ae342870fade",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Job ID for keyspace cleanup process"
           }
         },
         "summary" : "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately"
@@ -948,11 +1458,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "202" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "34034d36-3c1e-4bdb-8a8f-f92291a64cb3",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Job ID for successfully scheduled Cassandra node decommission request"
           }
         },
         "summary" : "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id."
@@ -969,11 +1484,16 @@
           }
         } ],
         "responses" : {
-          "default" : {
+          "202" : {
             "content" : {
-              "text/plain" : { }
+              "text/plain" : {
+                "example" : "34034d36-3c1e-4bdb-8a8f-f92291a64cb3",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
             },
-            "description" : "default response"
+            "description" : "Job ID for successfully scheduled Cassandra node rebuild request"
           }
         },
         "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id."
@@ -1077,6 +1597,32 @@
           }
         },
         "required" : [ "columns", "keyspace_name", "table_name" ]
+      },
+      "Job" : {
+        "type" : "object",
+        "properties" : {
+          "end_time" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "error" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "ERROR", "COMPLETED", "WAITING" ]
+          },
+          "submit_time" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
       },
       "KeyspaceRequest" : {
         "type" : "object",

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -112,6 +112,7 @@
         "parameters" : [ {
           "name" : "job_id",
           "in" : "query",
+          "required" : true,
           "schema" : {
             "type" : "string"
           }
@@ -216,6 +217,7 @@
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
+          "required" : true,
           "schema" : {
             "type" : "string"
           }
@@ -237,6 +239,7 @@
         "parameters" : [ {
           "name" : "keyspaceName",
           "in" : "query",
+          "required" : true,
           "schema" : {
             "type" : "string"
           }
@@ -623,7 +626,7 @@
     },
     "/api/v0/ops/node/repair" : {
       "post" : {
-        "summary" : "Perform a nodetool repair",
+        "summary" : "Execute a nodetool repair operation",
         "operationId" : "repair",
         "requestBody" : {
           "content" : {
@@ -753,7 +756,7 @@
     },
     "/api/v0/ops/tables/create" : {
       "post" : {
-        "summary" : "Create a new table",
+        "summary" : "Create a new table in an existing keyspace",
         "operationId" : "createTable",
         "requestBody" : {
           "content" : {

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -1174,10 +1174,6 @@
               "type" : "string"
             }
           },
-          "skip_flsuh" : {
-            "type" : "boolean",
-            "writeOnly" : true
-          },
           "skip_flush" : {
             "type" : "boolean"
           },

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -49,6 +49,46 @@
         }
       }
     },
+    "/api/v0/lifecycle/configure" : {
+      "post" : {
+        "description" : "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started",
+        "operationId" : "configureNode",
+        "parameters" : [ {
+          "name" : "profile",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "string"
+              }
+            },
+            "application/yaml" : {
+              "schema" : {
+                "type" : "string"
+              }
+            },
+            "text/yaml" : {
+              "schema" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "default" : {
+            "description" : "default response",
+            "content" : {
+              "*/*" : { }
+            }
+          }
+        }
+      }
+    },
     "/api/v0/probes/cluster" : {
       "get" : {
         "summary" : "Indicated whether the Cassandra cluster is able to achieve the specified consistency",
@@ -275,36 +315,6 @@
             "description" : "default response",
             "content" : {
               "text/plain" : { }
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/lifecycle/configure" : {
-      "post" : {
-        "description" : "Configure Cassandra. Will fail if Cassandra is already started",
-        "operationId" : "configureNodeJson",
-        "parameters" : [ {
-          "name" : "profile",
-          "in" : "query",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "default" : {
-            "description" : "default response",
-            "content" : {
-              "*/*" : { }
             }
           }
         }

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -17,7 +17,7 @@
         <rsapi.version>2.1.1</rsapi.version>
         <guava.version>30.1.1-jre</guava.version>
         <airline.version>2.7.0</airline.version>
-        <jaxrs.version>2.1.6</jaxrs.version>
+        <jaxrs.version>2.1.11</jaxrs.version>
         <resteasy.version>4.5.9.Final</resteasy.version>
         <netty.version>4.1.50.Final</netty.version>
         <cassandra3.version>3.11.11</cassandra3.version>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -17,7 +17,7 @@
         <rsapi.version>2.1.1</rsapi.version>
         <guava.version>30.1.1-jre</guava.version>
         <airline.version>2.7.0</airline.version>
-        <jaxrs.version>2.1.11</jaxrs.version>
+        <jaxrs.version>2.1.6</jaxrs.version>
         <resteasy.version>4.5.9.Final</resteasy.version>
         <netty.version>4.1.50.Final</netty.version>
         <cassandra3.version>3.11.11</cassandra3.version>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -315,6 +315,7 @@
                     <outputFormat>JSON</outputFormat>
                     <prettyPrint>TRUE</prettyPrint>
                     <configurationFilePath>${project.basedir}/src/main/resources/openapi-configuration.json</configurationFilePath>
+                    <sortOutput>true</sortOutput>
                     <skip>${skipOpenApi}</skip>
                 </configuration>
                 <executions>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -316,6 +316,7 @@
                     <outputFormat>JSON</outputFormat>
                     <prettyPrint>TRUE</prettyPrint>
                     <configurationFilePath>${project.basedir}/src/main/resources/openapi-configuration.json</configurationFilePath>
+                    <skip>${skipOpenApi}</skip>
                 </configuration>
                 <executions>
                     <execution>
@@ -333,6 +334,7 @@
                 <configuration>
                     <inputSpec>${project.basedir}/doc/openapi.json</inputSpec>
                     <generatorName>go</generatorName>
+                    <skip>${skipOpenApi}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -27,7 +27,6 @@
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.5.13</mockito.version>
         <servelet.version>3.1.0</servelet.version>
-        <openapi.tools.version>5.3.0</openapi.tools.version>
     </properties>
 
     <dependencies>
@@ -327,24 +326,39 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.openapitools</groupId>
-                <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>${openapi.tools.version}</version>
-                <configuration>
-                    <inputSpec>${project.basedir}/doc/openapi.json</inputSpec>
-                    <generatorName>go</generatorName>
-                    <skip>${skipOpenApi}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+    <profiles>
+      <profile>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+        <id>clientgen</id>
+        <properties>
+          <openapi.tools.version>5.3.0</openapi.tools.version>
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.openapitools</groupId>
+              <artifactId>openapi-generator-maven-plugin</artifactId>
+              <version>${openapi.tools.version}</version>
+              <configuration>
+                <inputSpec>${project.basedir}/doc/openapi.json</inputSpec>
+                <generatorName>go</generatorName>
+                <skip>${skipOpenApi}</skip>
+              </configuration>
+              <executions>
+                <execution>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>generate</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 </project>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -26,6 +26,8 @@
         <assertj.version>3.17.2</assertj.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.5.13</mockito.version>
+        <servelet.version>3.1.0</servelet.version>
+        <openapi.tools.version>5.3.0</openapi.tools.version>
     </properties>
 
     <dependencies>
@@ -88,6 +90,11 @@
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
             <version>${driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servelet.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
@@ -296,6 +303,43 @@
                                 </transformer>
                             </transformers>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>${jaxrs.version}</version>
+                <configuration>
+                    <outputFileName>openapi</outputFileName>
+                    <outputPath>${project.basedir}/doc</outputPath>
+                    <outputFormat>JSON</outputFormat>
+                    <prettyPrint>TRUE</prettyPrint>
+                    <configurationFilePath>${project.basedir}/src/main/resources/openapi-configuration.json</configurationFilePath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi.tools.version}</version>
+                <configuration>
+                    <inputSpec>${project.basedir}/doc/openapi.json</inputSpec>
+                    <generatorName>go</generatorName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
+import javax.ws.rs.Produces;
 
 @Path("/api/v0/ops/auth")
 public class AuthResources
@@ -37,7 +38,15 @@ public class AuthResources
     @POST
     @Path("/role/")
     @Operation(summary = "Creates a new user role", operationId = "createRole")
-    @ApiResponse(responseCode = "200", description = "Role created")
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Role created",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
     @ApiResponse(responseCode = "400", description = "Username and/or password is empty",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
@@ -34,7 +34,7 @@ public class AuthResources
 
     @POST
     @Path("/role/")
-    @Operation(summary = "Creates a new user role")
+    @Operation(summary = "Creates a new user role", operationId = "createRole")
     @Produces(MediaType.TEXT_PLAIN)
     public Response createRole(
             @QueryParam(value = "username")String name,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/AuthResources.java
@@ -7,7 +7,6 @@ package com.datastax.mgmtapi.resources;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -17,6 +16,9 @@ import org.apache.commons.lang3.StringUtils;
 import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
@@ -35,7 +37,15 @@ public class AuthResources
     @POST
     @Path("/role/")
     @Operation(summary = "Creates a new user role", operationId = "createRole")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Role created")
+    @ApiResponse(responseCode = "400", description = "Username and/or password is empty",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Username is empty"
+            )
+        )
+    )
     public Response createRole(
             @QueryParam(value = "username")String name,
             @QueryParam(value = "is_superuser") Boolean isSuperUser,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -29,6 +29,7 @@ import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
+import io.swagger.v3.oas.annotations.Parameter;
 
 
 @Path("/api/v0")
@@ -126,7 +127,7 @@ public class K8OperatorResources
     @GET
     @Path("/ops/executor/job")
     @Operation(summary = "Returns Job deatils for the supplied Job ID", operationId = "getJobStatus")
-    public Response getJobStatus(@QueryParam(value="job_id") String jobId) {
+    public Response getJobStatus(@Parameter(required = true) @QueryParam(value="job_id") String jobId) {
         return handle(() -> {
             Map<String, String> jobResponse = (Map<String, String>) ResponseTools.getSingleRowResponse(app.dbUnixSocketFile, cqlService, "CALL NodeOps.jobStatus(?)", jobId);
             if(jobResponse.isEmpty()) {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -10,12 +10,12 @@ import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
+import com.datastax.mgmtapi.resources.models.Job;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,6 +26,10 @@ import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
@@ -48,7 +52,14 @@ public class K8OperatorResources
     @GET
     @Path("/probes/liveness")
     @Operation(summary = "Indicates whether this service is running", operationId = "checkLiveness")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Service is running",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
     public Response checkLiveness()
     {
         return Response.ok("OK").build();
@@ -57,7 +68,15 @@ public class K8OperatorResources
     @GET
     @Path("/probes/readiness")
     @Operation(summary = "Indicates whether the Cassandra service is ready to service requests", operationId = "checkReadiness")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Service is ready to handle requests",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Service is not ready to handle requests")
     public Response checkReadiness()
     {
         return handle(() ->
@@ -80,6 +99,24 @@ public class K8OperatorResources
     @GET
     @Path("/probes/cluster")
     @Operation(summary = "Indicated whether the Cassandra cluster is able to achieve the specified consistency", operationId = "checkClusterConsistency")
+    @ApiResponse(responseCode = "200", description = "Cassandra is able to achieve the specified consistency")
+    @ApiResponse(responseCode = "500", description = "Cassandra is unable to achieve the specified consistency",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(
+                implementation = Map.class
+            ),
+            examples = @ExampleObject(
+                value = "{\n" +
+"    \"[-8842966077830801609, -7599446072150209635]\": [\n" +
+"        \"2 replicas required, but only 1 nodes in the ring\"\n" +
+"    ],\n" +
+"    \"[-7599446072150209635, -6632081829071674136]\": [\n" +
+"        \"2 replicas required, but only 1 nodes in the ring\"\n" +
+"    ]}"
+            )
+        )
+    )
     public Response checkClusterConsistency(@QueryParam(value="consistency_level")String consistencyLevelStr, @QueryParam(value = "rf_per_dc") Integer rfPerDcVal)
     {
         return handle(() ->
@@ -110,6 +147,13 @@ public class K8OperatorResources
     @POST
     @Path("/ops/seeds/reload")
     @Operation(summary = "Reload the seed node list from the seed provider", operationId = "seedReload")
+    @ApiResponse(responseCode = "200", description = "List of new seeds after reload",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "[127.0.0.1, 127.0.0.2]")
+        )
+    )
     public Response seedReload()
     {
         return handle(() ->
@@ -125,6 +169,12 @@ public class K8OperatorResources
     @GET
     @Path("/ops/executor/job")
     @Operation(summary = "Returns Job deatils for the supplied Job ID", operationId = "getJobStatus")
+    @ApiResponse(responseCode = "200", description = "Map of job details",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = Job.class)
+        )
+    )
     public Response getJobStatus(@Parameter(required = true) @QueryParam(value="job_id") String jobId) {
         return handle(() -> {
             Map<String, String> jobResponse = (Map<String, String>) ResponseTools.getSingleRowResponse(app.dbUnixSocketFile, cqlService, "CALL NodeOps.jobStatus(?)", jobId);

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -48,7 +48,7 @@ public class K8OperatorResources
 
     @GET
     @Path("/probes/liveness")
-    @Operation(summary = "Indicates whether this service is running")
+    @Operation(summary = "Indicates whether this service is running", operationId = "checkLiveness")
     @Produces(MediaType.TEXT_PLAIN)
     public Response checkLiveness()
     {
@@ -57,7 +57,7 @@ public class K8OperatorResources
 
     @GET
     @Path("/probes/readiness")
-    @Operation(summary = "Indicates whether the Cassandra service is ready to service requests")
+    @Operation(summary = "Indicates whether the Cassandra service is ready to service requests", operationId = "checkReadiness")
     @Produces(MediaType.TEXT_PLAIN)
     public Response checkReadiness()
     {
@@ -80,7 +80,7 @@ public class K8OperatorResources
 
     @GET
     @Path("/probes/cluster")
-    @Operation(summary = "Indicated whether the Cassandra cluster is able to achieve the specified consistency")
+    @Operation(summary = "Indicated whether the Cassandra cluster is able to achieve the specified consistency", operationId = "checkClusterConsistency")
     public Response checkClusterConsistency(@QueryParam(value="consistency_level")String consistencyLevelStr, @QueryParam(value = "rf_per_dc") Integer rfPerDcVal)
     {
         return handle(() ->
@@ -110,6 +110,7 @@ public class K8OperatorResources
 
     @POST
     @Path("/ops/seeds/reload")
+    @Operation(summary = "Reload the seed node list from the seed provider", operationId = "seedReload")
     public Response seedReload()
     {
         return handle(() ->
@@ -124,6 +125,7 @@ public class K8OperatorResources
 
     @GET
     @Path("/ops/executor/job")
+    @Operation(summary = "Returns Job deatils for the supplied Job ID", operationId = "getJobStatus")
     public Response getJobStatus(@QueryParam(value="job_id") String jobId) {
         return handle(() -> {
             Map<String, String> jobResponse = (Map<String, String>) ResponseTools.getSingleRowResponse(app.dbUnixSocketFile, cqlService, "CALL NodeOps.jobStatus(?)", jobId);

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -12,7 +12,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -20,16 +19,15 @@ import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.ConnectionClosedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
-import io.swagger.v3.oas.annotations.Parameter;
 
 
 @Path("/api/v0")

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/K8OperatorResources.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -52,6 +53,7 @@ public class K8OperatorResources
     @GET
     @Path("/probes/liveness")
     @Operation(summary = "Indicates whether this service is running", operationId = "checkLiveness")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Service is running",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -68,6 +70,7 @@ public class K8OperatorResources
     @GET
     @Path("/probes/readiness")
     @Operation(summary = "Indicates whether the Cassandra service is ready to service requests", operationId = "checkReadiness")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Service is ready to handle requests",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -99,6 +102,7 @@ public class K8OperatorResources
     @GET
     @Path("/probes/cluster")
     @Operation(summary = "Indicated whether the Cassandra cluster is able to achieve the specified consistency", operationId = "checkClusterConsistency")
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
     @ApiResponse(responseCode = "200", description = "Cassandra is able to achieve the specified consistency")
     @ApiResponse(responseCode = "500", description = "Cassandra is unable to achieve the specified consistency",
         content = @Content(
@@ -147,6 +151,7 @@ public class K8OperatorResources
     @POST
     @Path("/ops/seeds/reload")
     @Operation(summary = "Reload the seed node list from the seed provider", operationId = "seedReload")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "List of new seeds after reload",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -169,7 +174,14 @@ public class K8OperatorResources
     @GET
     @Path("/ops/executor/job")
     @Operation(summary = "Returns Job deatils for the supplied Job ID", operationId = "getJobStatus")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     @ApiResponse(responseCode = "200", description = "Map of job details",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = Job.class)
+        )
+    )
+    @ApiResponse(responseCode = "404", description = "Job not found",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
             schema = @Schema(implementation = Job.class)

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Response;
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.ConnectionClosedException;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +35,8 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.http.HttpStatus;
-
-import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 import io.swagger.v3.oas.annotations.Parameter;
+
 
 @Path("/api/v0/ops/keyspace")
 public class KeyspaceOpsResources

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -61,6 +61,7 @@ public class KeyspaceOpsResources
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.",
             operationId = "cleanup")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Job ID for keyspace cleanup process",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -99,6 +100,7 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/refresh")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "SSTables loaded successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -138,6 +140,7 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/create")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Keyspace created successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -179,6 +182,7 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/alter")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Keyspace Replication Settings altered successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -219,6 +223,7 @@ public class KeyspaceOpsResources
     }
 
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "List of Keyspaces",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -250,6 +255,7 @@ public class KeyspaceOpsResources
 
     @GET
     @Path("/replication")
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
     @ApiResponse(responseCode = "200", description = "Keyspace Replication Settings",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -57,7 +57,8 @@ public class KeyspaceOpsResources
     @Path("/cleanup")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.")
+    @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.",
+            operationId = "cleanup")
     public Response cleanup(KeyspaceRequest keyspaceRequest)
     {
         return NodeOpsResources.handle(() ->
@@ -86,7 +87,7 @@ public class KeyspaceOpsResources
     @POST
     @Path("/refresh")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Load newly placed SSTables to the system without restart")
+    @Operation(summary = "Load newly placed SSTables to the system without restart", operationId = "refresh")
     public Response refresh(@QueryParam(value="keyspaceName")String keyspaceName, @QueryParam(value="table")String table)
     {
         return NodeOpsResources.handle(() ->
@@ -111,7 +112,7 @@ public class KeyspaceOpsResources
     @Path("/create")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Create a new keyspace with the given name and replication settings")
+    @Operation(summary = "Create a new keyspace with the given name and replication settings", operationId = "createKeyspace")
     public Response create(CreateOrAlterKeyspaceRequest createOrAlterKeyspaceRequest)
     {
         return NodeOpsResources.handle(() ->
@@ -137,7 +138,7 @@ public class KeyspaceOpsResources
     @Path("/alter")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Alter the replication settings of an existing keyspace")
+    @Operation(summary = "Alter the replication settings of an existing keyspace", operationId = "alterKeyspace")
     public Response alter(CreateOrAlterKeyspaceRequest createOrAlterKeyspaceRequest)
     {
         return NodeOpsResources.handle(() ->
@@ -162,7 +163,7 @@ public class KeyspaceOpsResources
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "List the keyspaces existing in the cluster")
+    @Operation(summary = "List the keyspaces existing in the cluster", operationId = "listKeyspaces")
     public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
     {
         return NodeOpsResources.handle(() ->
@@ -186,7 +187,7 @@ public class KeyspaceOpsResources
     @Path("/replication")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Get the replication settings of an existing keyspace")
+    @Operation(summary = "Get the replication settings of an existing keyspace", operationId = "replication")
     public Response getReplication(@QueryParam(value="keyspaceName")String keyspaceName) {
         if (StringUtils.isBlank(keyspaceName)) {
             return Response.status(HttpStatus.SC_BAD_REQUEST)

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -36,6 +36,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 
 @Path("/api/v0/ops/keyspace")
@@ -55,9 +59,19 @@ public class KeyspaceOpsResources
     @POST
     @Path("/cleanup")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
     @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is blocking and will return the executed job after finishing.",
             operationId = "cleanup")
+    @ApiResponse(responseCode = "200", description = "Job ID for keyspace cleanup process",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = "d69d1d95-9348-4460-95d2-ae342870fade"
+            )
+        )
+    )
     public Response cleanup(KeyspaceRequest keyspaceRequest)
     {
         return NodeOpsResources.handle(() ->
@@ -85,7 +99,22 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/refresh")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "SSTables loaded successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Keyspace name or Table name not provided",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Must provide a keyspace name"
+            )
+        )
+    )
     @Operation(summary = "Load newly placed SSTables to the system without restart", operationId = "refresh")
     public Response refresh(@QueryParam(value="keyspaceName")String keyspaceName, @QueryParam(value="table")String table)
     {
@@ -109,7 +138,22 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/create")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Keyspace created successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Keyspace name or Replication Settings not provided",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Keyspace creation failed. Non-empty 'keyspace_name' must be provided"
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Create a new keyspace with the given name and replication settings", operationId = "createKeyspace")
     public Response create(CreateOrAlterKeyspaceRequest createOrAlterKeyspaceRequest)
@@ -135,7 +179,22 @@ public class KeyspaceOpsResources
 
     @POST
     @Path("/alter")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Keyspace Replication Settings altered successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Keyspace name or Replication Settings not provided",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Altering Keyspace failed. Non-empty 'keyspace_name' must be provided"
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Alter the replication settings of an existing keyspace", operationId = "alterKeyspace")
     public Response alter(CreateOrAlterKeyspaceRequest createOrAlterKeyspaceRequest)
@@ -160,7 +219,14 @@ public class KeyspaceOpsResources
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "List of Keyspaces",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            examples = @ExampleObject(
+                value = "[\n    \"system_schema\",\n    \"system\",\n    \"system_auth\",\n    \"system_distributed\",\n    \"system_traces\"\n]"
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "List the keyspaces existing in the cluster", operationId = "listKeyspaces")
     public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
@@ -184,7 +250,30 @@ public class KeyspaceOpsResources
 
     @GET
     @Path("/replication")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Keyspace Replication Settings",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            examples = @ExampleObject(
+                value = "{\n    \"class\": \"org.apache.cassandra.locator.SimpleStrategy\",\n    \"replication_factor\": \"2\"\n}"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Keyspace name not provided",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Get keyspace replication failed. Non-empty 'keyspaceName' must be provided"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "404", description = "Keyspace name not found",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Get keyspace replication failed. Keyspace 'my_keyspace' does not exist."
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the replication settings of an existing keyspace", operationId = "replication")
     public Response getReplication(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName) {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -165,7 +165,7 @@ public class KeyspaceOpsResources
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "List the keyspaces existing in the cluster", operationId = "listKeyspaces")
-    public Response list(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName)
+    public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
     {
         return NodeOpsResources.handle(() ->
         {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/KeyspaceOpsResources.java
@@ -38,6 +38,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import org.apache.http.HttpStatus;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Path("/api/v0/ops/keyspace")
 public class KeyspaceOpsResources
@@ -164,7 +165,7 @@ public class KeyspaceOpsResources
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "List the keyspaces existing in the cluster", operationId = "listKeyspaces")
-    public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
+    public Response list(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName)
     {
         return NodeOpsResources.handle(() ->
         {
@@ -188,7 +189,7 @@ public class KeyspaceOpsResources
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the replication settings of an existing keyspace", operationId = "replication")
-    public Response getReplication(@QueryParam(value="keyspaceName")String keyspaceName) {
+    public Response getReplication(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName) {
         if (StringUtils.isBlank(keyspaceName)) {
             return Response.status(HttpStatus.SC_BAD_REQUEST)
                     .entity("Get keyspace replication failed. Non-empty 'keyspaceName' must be provided").build();

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -72,7 +72,7 @@ public class LifecycleResources
      */
     @Path("/start")
     @POST
-    @Operation(description = "Starts Cassandra/DSE")
+    @Operation(description = "Starts Cassandra/DSE", operationId = "startNode")
     public synchronized Response startNode(@QueryParam("profile") String profile, @QueryParam("replace_ip") String replaceIp)
     {
         app.setRequestedState(STARTED);
@@ -198,7 +198,7 @@ public class LifecycleResources
 
     @Path("/stop")
     @POST
-    @Operation(description = "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called")
+    @Operation(description = "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called", operationId = "stopNode")
     public synchronized Response stopNode()
     {
         app.setRequestedState(STOPPED);
@@ -286,7 +286,7 @@ public class LifecycleResources
     @Path("/configure")
     @POST
     @Consumes("application/json")
-    @Operation(description = "Configure Cassandra. Will fail if Cassandra is already started")
+    @Operation(description = "Configure Cassandra. Will fail if Cassandra is already started", operationId = "configureNodeJson")
     public synchronized Response configureNodeJson(@QueryParam("profile") String profile, String config)
     {
         try {
@@ -301,7 +301,7 @@ public class LifecycleResources
     @Path("/configure")
     @POST
     @Consumes({"application/yaml", "text/yaml"})
-    @Operation(description = "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started")
+    @Operation(description = "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started", operationId = "configureNode")
     public synchronized Response configureNode(@QueryParam("profile") String profile, String yaml)
     {
         if (app.getRequestedState() == STARTED ) {
@@ -417,7 +417,7 @@ public class LifecycleResources
 
     @Path("/pid")
     @GET
-    @Operation(description = "The PID of Cassandra/DSE, if it's running")
+    @Operation(description = "The PID of Cassandra/DSE, if it's running", operationId = "getPID")
     public Response getPID()
     {
         try

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -79,6 +80,7 @@ public class LifecycleResources
     @Path("/start")
     @POST
     @Operation(description = "Starts Cassandra/DSE", operationId = "startNode")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "201", description = "Cassandra started successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -229,6 +231,7 @@ public class LifecycleResources
     @Path("/stop")
     @POST
     @Operation(description = "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called", operationId = "stopNode")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra stopped successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -341,6 +344,7 @@ public class LifecycleResources
     @POST
     @Consumes("application/json")
     @Operation(description = "Configure Cassandra. Will fail if Cassandra is already started", operationId = "configureNodeJson")
+    @Produces(MediaType.TEXT_PLAIN)
     public synchronized Response configureNodeJson(@QueryParam("profile") String profile, String config)
     {
         try {
@@ -358,6 +362,7 @@ public class LifecycleResources
     @POST
     @Consumes({"application/yaml", "text/yaml"})
     @Operation(description = "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started", operationId = "configureNode")
+    @Produces(MediaType.TEXT_PLAIN)
     public synchronized Response configureNode(@QueryParam("profile") String profile, String yaml)
     {
         if (app.getRequestedState() == STARTED ) {
@@ -474,6 +479,7 @@ public class LifecycleResources
     @Path("/pid")
     @GET
     @Operation(description = "The PID of Cassandra/DSE, if it's running", operationId = "getPID")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra Process ID",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.Response;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +38,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.http.HttpStatus;
 
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STARTED;
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STOPPED;
-import io.swagger.v3.oas.annotations.Hidden;
 
 @Path("/api/v0/lifecycle")
 public class LifecycleResources

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -18,6 +18,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.google.common.collect.ImmutableMap;
@@ -40,6 +41,10 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STARTED;
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STOPPED;
@@ -74,6 +79,30 @@ public class LifecycleResources
     @Path("/start")
     @POST
     @Operation(description = "Starts Cassandra/DSE", operationId = "startNode")
+    @ApiResponse(responseCode = "201", description = "Cassandra started successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "202", description = "Cassandra already running and can connect")
+    @ApiResponse(responseCode = "204", description = "Cassandra already running but can't connect")
+    @ApiResponse(responseCode = "206", description = "Cassandra process not found but can connect")
+    @ApiResponse(responseCode = "420", description = "Cassandra could not start successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "Error starting Cassandra")
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Error trying to start Cassandra",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "error message")
+        )
+    )
     public synchronized Response startNode(@QueryParam("profile") String profile, @QueryParam("replace_ip") String replaceIp)
     {
         app.setRequestedState(STARTED);
@@ -200,6 +229,20 @@ public class LifecycleResources
     @Path("/stop")
     @POST
     @Operation(description = "Stops Cassandra/DSE. Keeps node from restarting automatically until /start is called", operationId = "stopNode")
+    @ApiResponse(responseCode = "200", description = "Cassandra stopped successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "500", description = "Cassandra not stopped successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "Killing Cassandra Failed")
+        )
+    )
     public synchronized Response stopNode()
     {
         app.setRequestedState(STOPPED);
@@ -431,6 +474,21 @@ public class LifecycleResources
     @Path("/pid")
     @GET
     @Operation(description = "The PID of Cassandra/DSE, if it's running", operationId = "getPID")
+    @ApiResponse(responseCode = "200", description = "Cassandra Process ID",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "204", description = "No Cassandra Process running")
+    @ApiResponse(responseCode = "500", description = "Error finding Cassandra Process",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "error message")
+        )
+    )
     public Response getPID()
     {
         try

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -42,6 +42,7 @@ import org.apache.http.HttpStatus;
 
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STARTED;
 import static com.datastax.mgmtapi.ManagementApplication.STATE.STOPPED;
+import io.swagger.v3.oas.annotations.Hidden;
 
 @Path("/api/v0/lifecycle")
 public class LifecycleResources
@@ -284,6 +285,16 @@ public class LifecycleResources
     }
 
     @Path("/configure")
+    /**
+     * Hiding both "configure" endpoints to prevent OpenAPI spec generation from happening. Having 2
+     * methods handling the same endpoint and only differing on the @Consumes request MIME type causes
+     * the generation to fail to document the endpoint correctly. For now, we will annotate both these
+     * methods with @Hidden so that they still exist but are not auto generated in the spec file. They
+     * are documented by hand in the openapi-configuration.json file in the resources directory of this
+     * project for now, as that file is merged with the auto-generated spec to produce the final spec
+     * file.
+     */
+    @Hidden
     @POST
     @Consumes("application/json")
     @Operation(description = "Configure Cassandra. Will fail if Cassandra is already started", operationId = "configureNodeJson")
@@ -299,6 +310,8 @@ public class LifecycleResources
     }
 
     @Path("/configure")
+    // Hiding this. See above.
+    @Hidden
     @POST
     @Consumes({"application/yaml", "text/yaml"})
     @Operation(description = "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started", operationId = "configureNode")

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
@@ -42,7 +42,7 @@ public class MetadataResources
 
     @GET
     @Path("/versions/release")
-    @Operation(summary = "Returns the Cassandra release version")
+    @Operation(summary = "Returns the Cassandra release version", operationId = "getReleaseVersion")
     @Produces(MediaType.TEXT_PLAIN)
     public Response getReleaseVersion()
     {
@@ -51,7 +51,7 @@ public class MetadataResources
 
     @GET
     @Path("/endpoints")
-    @Operation(summary = "Returns this nodes view of the endpoint states of nodes")
+    @Operation(summary = "Returns this nodes view of the endpoint states of nodes", operationId = "getEndpointStates")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getEndpointStates()
     {
@@ -60,7 +60,7 @@ public class MetadataResources
 
     @GET
     @Path("/localdc")
-    @Operation(summary = "Returns the DataCenter the local node belongs to")
+    @Operation(summary = "Returns the DataCenter the local node belongs to", operationId = "getLocalDataCenter")
     @Produces(MediaType.TEXT_PLAIN)
     public Response getLocalDataCenter()
     {
@@ -69,7 +69,7 @@ public class MetadataResources
 
     @GET
     @Path("/versions/features")
-    @Operation(summary = "Returns the management-api featureSet")
+    @Operation(summary = "Returns the management-api featureSet", operationId = "getFeatureSet")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getFeatureSet() {
         return handle(() -> {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
@@ -14,15 +14,16 @@ import javax.ws.rs.core.Response;
 
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import com.datastax.mgmtapi.resources.models.FeatureSet;
-import org.apache.http.ConnectionClosedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
-import com.datastax.oss.driver.api.core.cql.ResultSet;
-import com.datastax.oss.driver.api.core.cql.Row;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
@@ -43,7 +44,17 @@ public class MetadataResources
     @GET
     @Path("/versions/release")
     @Operation(summary = "Returns the Cassandra release version", operationId = "getReleaseVersion")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra version'",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = "4.0.1"
+            )
+        )
+    )
     public Response getReleaseVersion()
     {
         return executeWithStringResponse(CASSANDRA_VERSION_CQL_STRING);
@@ -52,7 +63,17 @@ public class MetadataResources
     @GET
     @Path("/endpoints")
     @Operation(summary = "Returns this nodes view of the endpoint states of nodes", operationId = "getEndpointStates")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Endpoint states'",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = ENDPOINTS_RESPONSE_EXAMPLE
+            )
+        )
+    )
     public Response getEndpointStates()
     {
         return executeWithJSONResponse("CALL NodeOps.getEndpointStates()");
@@ -61,7 +82,17 @@ public class MetadataResources
     @GET
     @Path("/localdc")
     @Operation(summary = "Returns the DataCenter the local node belongs to", operationId = "getLocalDataCenter")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Local datacenter'",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = "datacenter1"
+            )
+        )
+    )
     public Response getLocalDataCenter()
     {
         return executeWithStringResponse("CALL NodeOps.getLocalDataCenter()");
@@ -70,7 +101,17 @@ public class MetadataResources
     @GET
     @Path("/versions/features")
     @Operation(summary = "Returns the management-api featureSet", operationId = "getFeatureSet")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Local datacenter'",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = FEATURES_RESPONSE_EXAMPLE
+            )
+        )
+    )
     public Response getFeatureSet() {
         return handle(() -> {
             String cassandraVersion = ResponseTools.getSingleRowStringResponse(app.dbUnixSocketFile, cqlService, CASSANDRA_VERSION_CQL_STRING);
@@ -105,4 +146,59 @@ public class MetadataResources
         return handle(() ->
                 Response.ok(Entity.json(ResponseTools.getSingleRowResponse(app.dbUnixSocketFile, cqlService, query))).build());
     }
+    
+    private static final String ENDPOINTS_RESPONSE_EXAMPLE = "{\n" +
+"    \"entity\": [\n" +
+"        {\n" +
+"            \"DC\": \"datacenter1\",\n" +
+"            \"ENDPOINT_IP\": \"172.17.0.2\",\n" +
+"            \"HOST_ID\": \"5d2318b0-cfec-4697-8ed2-014b5f434ae8\",\n" +
+"            \"IS_ALIVE\": \"true\",\n" +
+"            \"LOAD\": \"135527.0\",\n" +
+"            \"NATIVE_ADDRESS_AND_PORT\": \"172.17.0.2:9042\",\n" +
+"            \"NET_VERSION\": \"12\",\n" +
+"            \"RACK\": \"rack1\",\n" +
+"            \"RELEASE_VERSION\": \"4.0.1\",\n" +
+"            \"RPC_ADDRESS\": \"172.17.0.2\",\n" +
+"            \"RPC_READY\": \"true\",\n" +
+"            \"SCHEMA\": \"2207c2a9-f598-3971-986b-2926e09e239d\",\n" +
+"            \"SSTABLE_VERSIONS\": \"big-nb\",\n" +
+"            \"STATUS\": \"NORMAL,-2444908528344618126\",\n" +
+"            \"STATUS_WITH_PORT\": \"NORMAL,-2444908528344618126\"\n," +
+"            \"TOKENS\": \"<tokens>\"\n" +
+"        }\n" +
+"    ],\n" +
+"    \"variant\": {\n" +
+"        \"language\": null,\n" +
+"        \"mediaType\": {\n" +
+"            \"type\": \"application\",\n" +
+"            \"subtype\": \"json\",\n" +
+"            \"parameters\": {},\n" +
+"            \"wildcardType\": false,\n" +
+"            \"wildcardSubtype\": false\n" +
+"        },\n" +
+"        \"encoding\": null,\n" +
+"        \"languageString\": null\n" +
+"    },\n" +
+"    \"annotations\": [],\n" +
+"    \"mediaType\": {\n" +
+"        \"type\": \"application\",\n" +
+"        \"subtype\": \"json\",\n" +
+"        \"parameters\": {},\n" +
+"        \"wildcardType\": false,\n" +
+"        \"wildcardSubtype\": false\n" +
+"    },\n" +
+"    \"language\": null,\n" +
+"    \"encoding\": null\n" +
+"}";
+
+    private static final String FEATURES_RESPONSE_EXAMPLE = "{\n" +
+"    \"cassandra_version\": \"4.0.1\",\n" +
+"    \"mgmt_version\": \"\",\n" +
+"    \"features\": [\n" +
+"        \"async_sstable_tasks\",\n" +
+"        \"full_query_logging\",\n" +
+"        \"rebuild\"\n" +
+"    ]\n" +
+"}";
 }

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
@@ -108,12 +108,7 @@ public class MetadataResources
     @ApiResponse(responseCode = "200", description = "Local datacenter'",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
-            schema = @Schema(
-                implementation = String.class
-            ),
-            examples = @ExampleObject(
-                value = FEATURES_RESPONSE_EXAMPLE
-            )
+            schema = @Schema(implementation = FeatureSet.class)
         )
     )
     public Response getFeatureSet() {
@@ -194,15 +189,5 @@ public class MetadataResources
 "    },\n" +
 "    \"language\": null,\n" +
 "    \"encoding\": null\n" +
-"}";
-
-    private static final String FEATURES_RESPONSE_EXAMPLE = "{\n" +
-"    \"cassandra_version\": \"4.0.1\",\n" +
-"    \"mgmt_version\": \"\",\n" +
-"    \"features\": [\n" +
-"        \"async_sstable_tasks\",\n" +
-"        \"full_query_logging\",\n" +
-"        \"rebuild\"\n" +
-"    ]\n" +
 "}";
 }

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/MetadataResources.java
@@ -44,6 +44,7 @@ public class MetadataResources
     @GET
     @Path("/versions/release")
     @Operation(summary = "Returns the Cassandra release version", operationId = "getReleaseVersion")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra version'",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -63,6 +64,7 @@ public class MetadataResources
     @GET
     @Path("/endpoints")
     @Operation(summary = "Returns this nodes view of the endpoint states of nodes", operationId = "getEndpointStates")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "Endpoint states'",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -82,6 +84,7 @@ public class MetadataResources
     @GET
     @Path("/localdc")
     @Operation(summary = "Returns the DataCenter the local node belongs to", operationId = "getLocalDataCenter")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Local datacenter'",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -101,6 +104,7 @@ public class MetadataResources
     @GET
     @Path("/versions/features")
     @Operation(summary = "Returns the management-api featureSet", operationId = "getFeatureSet")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "Local datacenter'",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -92,7 +92,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/decommission")
-    @Operation(summary = "Decommission the *node I am connecting to*")
+    @Operation(summary = "Decommission the *node I am connecting to*", operationId = "decommission")
     @Produces(MediaType.TEXT_PLAIN)
     public Response decommission(@QueryParam(value="force")boolean force)
     {
@@ -106,7 +106,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/compaction")
-    @Operation(summary = "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling")
+    @Operation(summary = "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling", operationId = "setCompactionThroughput")
     @Produces(MediaType.TEXT_PLAIN)
     public Response setCompactionThroughput(@QueryParam(value="value")int value)
     {
@@ -120,7 +120,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/assassinate")
-    @Operation(summary = "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode")
+    @Operation(summary = "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode", operationId = "assassinate")
     @Produces(MediaType.TEXT_PLAIN)
     public Response assassinate(@QueryParam(value="address")String address)
     {
@@ -138,7 +138,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/logging")
-    @Operation(summary = "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters.")
+    @Operation(summary = "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters.", operationId = "setLoggingLevel")
     @Produces(MediaType.TEXT_PLAIN)
     public Response setLoggingLevel(@QueryParam(value="target")String targetStr, @QueryParam(value="rawLevel")String rawLevelStr)
     {
@@ -162,7 +162,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/drain")
-    @Operation(summary = "Drain the node (stop accepting writes and flush all tables)")
+    @Operation(summary = "Drain the node (stop accepting writes and flush all tables)", operationId = "drain")
     @Produces(MediaType.TEXT_PLAIN)
     // TODO Make async
     public Response drain()
@@ -185,7 +185,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/hints/truncate")
-    @Operation(summary = "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified.")
+    @Operation(summary = "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified.", operationId = "truncateHints")
     @Produces(MediaType.TEXT_PLAIN)
     public Response truncateHints(@QueryParam(value="host")String host)
     {
@@ -207,7 +207,7 @@ public class NodeOpsResources
     @POST
     @Path("/schema/reset")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Reset node's local schema and resync")
+    @Operation(summary = "Reset node's local schema and resync", operationId = "resetLocalSchema")
     public Response resetLocalSchema()
     {
         return handle(() ->
@@ -221,7 +221,7 @@ public class NodeOpsResources
     @POST
     @Path("/schema/reload")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Reload local node schema from system tables")
+    @Operation(summary = "Reload local node schema from system tables", operationId = "reloadLocalSchema")
     public Response reloadLocalSchema()
     {
         return handle(() ->
@@ -235,7 +235,7 @@ public class NodeOpsResources
     @GET
     @Path("/streaminfo")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve Streaming status information")
+    @Operation(summary = "Retrieve Streaming status information", operationId = "getStreamInfo")
     public Response getStreamInfo()
     {
         return handle(() ->
@@ -254,7 +254,7 @@ public class NodeOpsResources
     @GET
     @Path("/snapshots")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Retrieve snapshot details")
+    @Operation(summary = "Retrieve snapshot details", operationId = "getSnapshotDetails")
     public Response getSnapshotDetails(@QueryParam("snapshotNames") List<String> snapshotNames, @QueryParam("keyspaces") List<String> keyspace)
     {
         return handle(() ->
@@ -273,7 +273,7 @@ public class NodeOpsResources
     @POST
     @Path("/snapshots")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Take a snapshot")
+    @Operation(summary = "Take a snapshot", operationId = "takeSnapshot")
     public Response takeSnapshot(TakeSnapshotRequest takeSnapshotRequest)
     {
         return handle(() ->
@@ -316,7 +316,7 @@ public class NodeOpsResources
     @DELETE
     @Path("/snapshots")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Clear snapshots")
+    @Operation(summary = "Clear snapshots", operationId = "clearSnapshots")
     public Response clearSnapshots(@QueryParam(value="snapshotNames") List<String> snapshotNames, @QueryParam(value="keyspaces") List<String> keyspaces)
     {
         return handle(() ->
@@ -329,7 +329,7 @@ public class NodeOpsResources
     @POST
     @Path("/repair")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Perform a nodetool repair")
+    @Operation(summary = "Perform a nodetool repair", operationId = "repair")
     public Response repair(RepairRequest repairRequest)
     {
         return handle(() ->
@@ -351,7 +351,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/fullquerylogging")
-    @Operation(summary = "Enable or disable full query logging facility.")
+    @Operation(summary = "Enable or disable full query logging facility.", operationId = "setFullQuerylog")
     @Produces(MediaType.TEXT_PLAIN)
     public Response setFullQuerylog(@QueryParam(value="enabled")boolean fullQueryLoggingEnabled)
     {
@@ -364,7 +364,7 @@ public class NodeOpsResources
 
     @GET
     @Path("/fullquerylogging")
-    @Operation(summary = "Get whether full query logging is enabled.")
+    @Operation(summary = "Get whether full query logging is enabled.", operationId = "isFullQueryLogEnabled")
     @Produces(MediaType.APPLICATION_JSON)
     public Response isFullQueryLogEnabled()
     {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -10,7 +10,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -38,6 +37,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
@@ -94,7 +97,13 @@ public class NodeOpsResources
     @POST
     @Path("/decommission")
     @Operation(summary = "Decommission the *node I am connecting to*", operationId = "decommission")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node decommissioned successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     public Response decommission(@QueryParam(value="force")boolean force)
     {
         return handle(() ->
@@ -108,7 +117,13 @@ public class NodeOpsResources
     @POST
     @Path("/compaction")
     @Operation(summary = "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling", operationId = "setCompactionThroughput")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra compaction throughput set successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     public Response setCompactionThroughput(@QueryParam(value="value")int value)
     {
         return handle(() ->
@@ -122,7 +137,20 @@ public class NodeOpsResources
     @POST
     @Path("/assassinate")
     @Operation(summary = "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode", operationId = "assassinate")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node assasinated successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Cassandra node assasination request missing address",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "Address must be provided")
+        )
+    )
     public Response assassinate(@QueryParam(value="address")String address)
     {
         return handle(() ->
@@ -140,7 +168,13 @@ public class NodeOpsResources
     @POST
     @Path("/logging")
     @Operation(summary = "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters.", operationId = "setLoggingLevel")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra logging level set successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     public Response setLoggingLevel(@QueryParam(value="target")String targetStr, @QueryParam(value="rawLevel")String rawLevelStr)
     {
         return handle(() ->
@@ -164,7 +198,13 @@ public class NodeOpsResources
     @POST
     @Path("/drain")
     @Operation(summary = "Drain the node (stop accepting writes and flush all tables)", operationId = "drain")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node drained successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     // TODO Make async
     public Response drain()
     {
@@ -187,7 +227,13 @@ public class NodeOpsResources
     @POST
     @Path("/hints/truncate")
     @Operation(summary = "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified.", operationId = "truncateHints")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node hints truncated successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     public Response truncateHints(@QueryParam(value="host")String host)
     {
         return handle(() ->
@@ -207,7 +253,13 @@ public class NodeOpsResources
 
     @POST
     @Path("/schema/reset")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node scheam resynced successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     @Operation(summary = "Reset node's local schema and resync", operationId = "resetLocalSchema")
     public Response resetLocalSchema()
     {
@@ -221,7 +273,13 @@ public class NodeOpsResources
 
     @POST
     @Path("/schema/reload")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cassandra node schema reloaded successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     @Operation(summary = "Reload local node schema from system tables", operationId = "reloadLocalSchema")
     public Response reloadLocalSchema()
     {
@@ -235,7 +293,13 @@ public class NodeOpsResources
 
     @GET
     @Path("/streaminfo")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Cassandra streaming status info",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = STREAMING_INFO_RESPONSE_EXAMPLE)
+        )
+    )
     @Operation(summary = "Retrieve Streaming status information", operationId = "getStreamInfo")
     public Response getStreamInfo()
     {
@@ -254,7 +318,13 @@ public class NodeOpsResources
 
     @GET
     @Path("/snapshots")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Cassandra snapshot details",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = SNAPSHOT_DETAILS_RESPONSE_EXAMPLE)
+        )
+    )
     @Operation(summary = "Retrieve snapshot details", operationId = "getSnapshotDetails")
     public Response getSnapshotDetails(@QueryParam("snapshotNames") List<String> snapshotNames, @QueryParam("keyspaces") List<String> keyspace)
     {
@@ -274,7 +344,20 @@ public class NodeOpsResources
     @POST
     @Path("/snapshots")
     @Consumes("application/json")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Snapshot created successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Invalid snapshot request",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "When specifying keyspace_tables, specifying keyspaces is not allowed")
+        )
+    )
     @Operation(summary = "Take a snapshot", operationId = "takeSnapshot")
     public Response takeSnapshot(TakeSnapshotRequest takeSnapshotRequest)
     {
@@ -317,7 +400,13 @@ public class NodeOpsResources
 
     @DELETE
     @Path("/snapshots")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Snapshots cleared successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     @Operation(summary = "Clear snapshots", operationId = "clearSnapshots")
     public Response clearSnapshots(@QueryParam(value="snapshotNames") List<String> snapshotNames, @QueryParam(value="keyspaces") List<String> keyspaces)
     {
@@ -330,7 +419,20 @@ public class NodeOpsResources
 
     @POST
     @Path("/repair")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Nodetool repair executed successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Repair request missing Keyspace name",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "keyspaceName must be specified")
+        )
+    )
     @Operation(summary = "Execute a nodetool repair operation", operationId = "repair")
     public Response repair(RepairRequest repairRequest)
     {
@@ -354,7 +456,13 @@ public class NodeOpsResources
     @POST
     @Path("/fullquerylogging")
     @Operation(summary = "Enable or disable full query logging facility.", operationId = "setFullQuerylog")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Full Query Logging set successfully",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "OK")
+        )
+    )
     public Response setFullQuerylog(@QueryParam(value="enabled")boolean fullQueryLoggingEnabled)
     {
         return handle(() ->
@@ -367,7 +475,13 @@ public class NodeOpsResources
     @GET
     @Path("/fullquerylogging")
     @Operation(summary = "Get whether full query logging is enabled.", operationId = "isFullQueryLogEnabled")
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Full Query enabled",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = FQL_QUERY_RESPONSE_EXAMPLE)
+        )
+    )
     public Response isFullQueryLogEnabled()
     {
         return handle(() ->
@@ -396,4 +510,97 @@ public class NodeOpsResources
             return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).entity(t.getLocalizedMessage()).build();
         }
     }
+
+    private static final String STREAMING_INFO_RESPONSE_EXAMPLE = "{\n" +
+"    \"entity\": [],\n" +
+"    \"variant\": {\n" +
+"        \"language\": null,\n" +
+"        \"mediaType\": {\n" +
+"            \"type\": \"application\",\n" +
+"            \"subtype\": \"json\",\n" +
+"            \"parameters\": {},\n" +
+"            \"wildcardType\": false,\n" +
+"            \"wildcardSubtype\": false\n" +
+"        },\n" +
+"        \"encoding\": null,\n" +
+"        \"languageString\": null\n" +
+"    },\n" +
+"    \"annotations\": [],\n" +
+"    \"mediaType\": {\n" +
+"        \"type\": \"application\",\n" +
+"        \"subtype\": \"json\",\n" +
+"        \"parameters\": {},\n" +
+"        \"wildcardType\": false,\n" +
+"        \"wildcardSubtype\": false\n" +
+"    },\n" +
+"    \"language\": null,\n" +
+"    \"encoding\": null\n" +
+"}";
+
+    private static final String SNAPSHOT_DETAILS_RESPONSE_EXAMPLE = "{\n" +
+"    \"entity\": [\n" +
+"        {\n" +
+"            \"Column family name\": \"size_estimates\",\n" +
+"            \"Keyspace name\": \"system\",\n" +
+"            \"Size on disk\": \"13 bytes\",\n" +
+"            \"Snapshot name\": \"truncated-1639687082845-size_estimates\",\n" +
+"            \"True size\": \"0 bytes\"\n" +
+"        },\n" +
+"        {\n" +
+"            \"Column family name\": \"table_estimates\",\n" +
+"            \"Keyspace name\": \"system\",\n" +
+"            \"Size on disk\": \"13 bytes\",\n" +
+"            \"Snapshot name\": \"truncated-1639687082982-table_estimates\",\n" +
+"            \"True size\": \"0 bytes\"\n" +
+"        }\n" +
+"    ],\n" +
+"    \"variant\": {\n" +
+"        \"language\": null,\n" +
+"        \"mediaType\": {\n" +
+"            \"type\": \"application\",\n" +
+"            \"subtype\": \"json\",\n" +
+"            \"parameters\": {},\n" +
+"            \"wildcardType\": false,\n" +
+"            \"wildcardSubtype\": false\n" +
+"        },\n" +
+"        \"encoding\": null,\n" +
+"        \"languageString\": null\n" +
+"    },\n" +
+"    \"annotations\": [],\n" +
+"    \"mediaType\": {\n" +
+"        \"type\": \"application\",\n" +
+"        \"subtype\": \"json\",\n" +
+"        \"parameters\": {},\n" +
+"        \"wildcardType\": false,\n" +
+"        \"wildcardSubtype\": false\n" +
+"    },\n" +
+"    \"language\": null,\n" +
+"    \"encoding\": null\n" +
+"}";
+
+    private static final String FQL_QUERY_RESPONSE_EXAMPLE = "{\n" +
+"    \"entity\": false,\n" +
+"    \"variant\": {\n" +
+"        \"language\": null,\n" +
+"        \"mediaType\": {\n" +
+"            \"type\": \"application\",\n" +
+"            \"subtype\": \"json\",\n" +
+"            \"parameters\": {},\n" +
+"            \"wildcardType\": false,\n" +
+"            \"wildcardSubtype\": false\n" +
+"        },\n" +
+"        \"encoding\": null,\n" +
+"        \"languageString\": null\n" +
+"    },\n" +
+"    \"annotations\": [],\n" +
+"    \"mediaType\": {\n" +
+"        \"type\": \"application\",\n" +
+"        \"subtype\": \"json\",\n" +
+"        \"parameters\": {},\n" +
+"        \"wildcardType\": false,\n" +
+"        \"wildcardSubtype\": false\n" +
+"    },\n" +
+"    \"language\": null,\n" +
+"    \"encoding\": null\n" +
+"}";
 }

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -5,6 +5,7 @@
  */
 package com.datastax.mgmtapi.resources;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -272,6 +273,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/snapshots")
+    @Consumes("application/json")
     @Produces(MediaType.TEXT_PLAIN)
     @Operation(summary = "Take a snapshot", operationId = "takeSnapshot")
     public Response takeSnapshot(TakeSnapshotRequest takeSnapshotRequest)

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -10,6 +10,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -97,6 +98,7 @@ public class NodeOpsResources
     @POST
     @Path("/decommission")
     @Operation(summary = "Decommission the *node I am connecting to*", operationId = "decommission")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node decommissioned successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -117,6 +119,7 @@ public class NodeOpsResources
     @POST
     @Path("/compaction")
     @Operation(summary = "Set the MB/s throughput cap for compaction in the system, or 0 to disable throttling", operationId = "setCompactionThroughput")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra compaction throughput set successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -137,6 +140,7 @@ public class NodeOpsResources
     @POST
     @Path("/assassinate")
     @Operation(summary = "Forcefully remove a dead node without re-replicating any data. Use as a last resort if you cannot removenode", operationId = "assassinate")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node assasinated successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -168,6 +172,7 @@ public class NodeOpsResources
     @POST
     @Path("/logging")
     @Operation(summary = "Set the log level threshold for a given component or class. Will reset to the initial configuration if called with no parameters.", operationId = "setLoggingLevel")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra logging level set successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -198,6 +203,7 @@ public class NodeOpsResources
     @POST
     @Path("/drain")
     @Operation(summary = "Drain the node (stop accepting writes and flush all tables)", operationId = "drain")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node drained successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -227,6 +233,7 @@ public class NodeOpsResources
     @POST
     @Path("/hints/truncate")
     @Operation(summary = "Truncate all hints on the local node, or truncate hints for the endpoint(s) specified.", operationId = "truncateHints")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node hints truncated successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -253,6 +260,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/schema/reset")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node scheam resynced successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -273,6 +281,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/schema/reload")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cassandra node schema reloaded successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -293,6 +302,7 @@ public class NodeOpsResources
 
     @GET
     @Path("/streaminfo")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "Cassandra streaming status info",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -318,6 +328,7 @@ public class NodeOpsResources
 
     @GET
     @Path("/snapshots")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "Cassandra snapshot details",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -344,6 +355,7 @@ public class NodeOpsResources
     @POST
     @Path("/snapshots")
     @Consumes("application/json")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Snapshot created successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -400,6 +412,7 @@ public class NodeOpsResources
 
     @DELETE
     @Path("/snapshots")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Snapshots cleared successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -419,6 +432,7 @@ public class NodeOpsResources
 
     @POST
     @Path("/repair")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Nodetool repair executed successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -456,6 +470,7 @@ public class NodeOpsResources
     @POST
     @Path("/fullquerylogging")
     @Operation(summary = "Enable or disable full query logging facility.", operationId = "setFullQuerylog")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Full Query Logging set successfully",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -475,6 +490,7 @@ public class NodeOpsResources
     @GET
     @Path("/fullquerylogging")
     @Operation(summary = "Get whether full query logging is enabled.", operationId = "isFullQueryLogEnabled")
+    @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(responseCode = "200", description = "Full Query enabled",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/NodeOpsResources.java
@@ -329,7 +329,7 @@ public class NodeOpsResources
     @POST
     @Path("/repair")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Perform a nodetool repair", operationId = "repair")
+    @Operation(summary = "Execute a nodetool repair operation", operationId = "repair")
     public Response repair(RepairRequest repairRequest)
     {
         return handle(() ->

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -32,9 +32,9 @@ import org.slf4j.LoggerFactory;
 import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
-import io.swagger.v3.oas.annotations.Parameter;
 
 @Path("/api/v0/ops/tables")
 public class TableOpsResources

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -52,7 +52,7 @@ public class TableOpsResources
     @Path("/scrub")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Scrub (rebuild sstables for) one or more tables")
+    @Operation(summary = "Scrub (rebuild sstables for) one or more tables", operationId = "scrub")
     public Response scrub(ScrubRequest scrubRequest)
     {
         return handle(() ->
@@ -80,7 +80,8 @@ public class TableOpsResources
     @Path("/sstables/upgrade")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)")
+    @Operation(summary = "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
+            operationId = "upgradeSSTables")
     public Response upgradeSSTables(@QueryParam(value="excludeCurrentVersion")boolean excludeCurrentVersion, KeyspaceRequest keyspaceRequest)
     {
         return handle(() ->
@@ -107,7 +108,8 @@ public class TableOpsResources
     @Path("/compact")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables")
+    @Operation(summary = "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables",
+            operationId = "compact")
     public Response compact(CompactRequest compactRequest)
     {
         return handle(() ->
@@ -171,7 +173,7 @@ public class TableOpsResources
     @Path("/garbagecollect")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Remove deleted data from one or more tables")
+    @Operation(summary = "Remove deleted data from one or more tables", operationId = "garbageCollect")
     public Response garbageCollect(@QueryParam(value="tombstoneOption")String tombstoneOptionStr, KeyspaceRequest keyspaceRequest)
     {
         return handle(() ->
@@ -208,7 +210,7 @@ public class TableOpsResources
     @Path("/flush")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Flush one or more tables")
+    @Operation(summary = "Flush one or more tables", operationId = "flush")
     public Response flush(KeyspaceRequest keyspaceRequest)
     {
         return handle(() ->
@@ -234,7 +236,7 @@ public class TableOpsResources
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "List the table names in the given keyspace")
+    @Operation(summary = "List the table names in the given keyspace", operationId = "listTables")
     public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
     {
         if (StringUtils.isBlank(keyspaceName))
@@ -256,7 +258,7 @@ public class TableOpsResources
     @Path("/create")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Create a new table")
+    @Operation(summary = "Create a new table", operationId = "createTable")
     public Response create(CreateTableRequest request)
     {
         try {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -258,7 +258,7 @@ public class TableOpsResources
     @Path("/create")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Create a new table", operationId = "createTable")
+    @Operation(summary = "Create a new table in an existing keyspace", operationId = "createTable")
     public Response create(CreateTableRequest request)
     {
         try {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -55,6 +55,7 @@ public class TableOpsResources
     @POST
     @Path("/scrub")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Table scrub successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -90,6 +91,7 @@ public class TableOpsResources
     @POST
     @Path("/sstables/upgrade")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "SSTable upgrade successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -125,6 +127,7 @@ public class TableOpsResources
     @POST
     @Path("/compact")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Table compaction successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -205,6 +208,7 @@ public class TableOpsResources
     @POST
     @Path("/garbagecollect")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Table garbage collection successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -257,6 +261,7 @@ public class TableOpsResources
     @POST
     @Path("/flush")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Table flush successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -289,6 +294,7 @@ public class TableOpsResources
     }
 
     @GET
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
     @ApiResponse(responseCode = "200", description = "Table list",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON,
@@ -326,6 +332,7 @@ public class TableOpsResources
 
     @POST
     @Path("/create")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Table creation successful",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -33,6 +33,9 @@ import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
@@ -52,7 +55,14 @@ public class TableOpsResources
     @POST
     @Path("/scrub")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Table scrub successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
     @Operation(summary = "Scrub (rebuild sstables for) one or more tables", operationId = "scrub")
     public Response scrub(ScrubRequest scrubRequest)
     {
@@ -80,7 +90,14 @@ public class TableOpsResources
     @POST
     @Path("/sstables/upgrade")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "SSTable upgrade successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
     @Operation(summary = "Rewrite sstables (for the requested tables) that are not on the current version (thus upgrading them to said current version)",
             operationId = "upgradeSSTables")
     public Response upgradeSSTables(@QueryParam(value="excludeCurrentVersion")boolean excludeCurrentVersion, KeyspaceRequest keyspaceRequest)
@@ -108,7 +125,22 @@ public class TableOpsResources
     @POST
     @Path("/compact")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Table compaction successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Invalid table compaction request",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Invalid option combination: Can not use split-output here"
+            )
+        )
+    )
     @Operation(summary = "Force a (major) compaction on one or more tables or user-defined compaction on given SSTables",
             operationId = "compact")
     public Response compact(CompactRequest compactRequest)
@@ -173,7 +205,22 @@ public class TableOpsResources
     @POST
     @Path("/garbagecollect")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Table garbage collection successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Invalid table garbage collection request",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "tombstoneOption must be either ROW or CELL"
+            )
+        )
+    )
     @Operation(summary = "Remove deleted data from one or more tables", operationId = "garbageCollect")
     public Response garbageCollect(@QueryParam(value="tombstoneOption")String tombstoneOptionStr, KeyspaceRequest keyspaceRequest)
     {
@@ -210,7 +257,14 @@ public class TableOpsResources
     @POST
     @Path("/flush")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Table flush successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
     @Operation(summary = "Flush one or more tables", operationId = "flush")
     public Response flush(KeyspaceRequest keyspaceRequest)
     {
@@ -235,7 +289,22 @@ public class TableOpsResources
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Table list",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON,
+            examples = @ExampleObject(
+                value = "[\n    \"table_1\",\n    \"table_2\"\n]"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Keyspace name not provided",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "List tables failed. Non-empty 'keyspaceName' must be provided"
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "List the table names in the given keyspace", operationId = "listTables")
     public Response list(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName)
@@ -257,7 +326,22 @@ public class TableOpsResources
 
     @POST
     @Path("/create")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Table creation successful",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "400", description = "Table creation failed",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            examples = @ExampleObject(
+                value = "Table creation failed: some failure message"
+            )
+        )
+    )
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Create a new table in an existing keyspace", operationId = "createTable")
     public Response create(CreateTableRequest request)

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -34,6 +34,7 @@ import com.datastax.mgmtapi.ManagementApplication;
 import io.swagger.v3.oas.annotations.Operation;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Path("/api/v0/ops/tables")
 public class TableOpsResources
@@ -237,7 +238,7 @@ public class TableOpsResources
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "List the table names in the given keyspace", operationId = "listTables")
-    public Response list(@QueryParam(value="keyspaceName")String keyspaceName)
+    public Response list(@Parameter(required = true) @QueryParam(value="keyspaceName")String keyspaceName)
     {
         if (StringUtils.isBlank(keyspaceName))
         {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/models/TakeSnapshotRequest.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/models/TakeSnapshotRequest.java
@@ -34,7 +34,7 @@ public class TakeSnapshotRequest implements Serializable {
             @JsonProperty("snapshot_name") String snapshotName,
             @JsonProperty("keyspaces") List<String> keyspaces,
             @JsonProperty("table_name") String tableName,
-            @JsonProperty("skip_flsuh") Boolean skipFlush,
+            @JsonProperty(value = "skip_flush") Boolean skipFlush,
             @JsonProperty("keyspace_tables") List<String> keyspaceTables)
     {
         this.snapshotName = snapshotName == null ? Long.toString(System.currentTimeMillis()) : snapshotName;;

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
@@ -33,7 +33,8 @@ public class KeyspaceOpsResources {
     @Path("/cleanup")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately")
+    @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
+            operationId = "cleanup_v1")
     public Response cleanup(KeyspaceRequest keyspaceRequest)
     {
         return NodeOpsResources.handle(() ->

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ public class KeyspaceOpsResources {
     @POST
     @Path("/cleanup")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "200", description = "Cleanup not needed for tables 'system' or 'system_schema'",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/KeyspaceOpsResources.java
@@ -6,13 +6,16 @@ import com.datastax.mgmtapi.resources.NodeOpsResources;
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import com.datastax.mgmtapi.resources.models.KeyspaceRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -32,7 +35,28 @@ public class KeyspaceOpsResources {
     @POST
     @Path("/cleanup")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "200", description = "Cleanup not needed for tables 'system' or 'system_schema'",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = "OK"
+            )
+        )
+    )
+    @ApiResponse(responseCode = "202", description = "Job ID for keyspace cleanup process",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(
+                implementation = String.class
+            ),
+            examples = @ExampleObject(
+                value = "d69d1d95-9348-4460-95d2-ae342870fade"
+            )
+        )
+    )
     @Operation(summary = "Triggers the immediate cleanup of keys no longer belonging to a node. By default, clean all keyspaces. This operation is asynchronous and returns immediately",
             operationId = "cleanup_v1")
     public Response cleanup(KeyspaceRequest keyspaceRequest)

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -29,6 +30,7 @@ public class NodeOpsResources {
     @POST
     @Path("/decommission")
     @Operation(summary = "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.", operationId = "decommission_v1")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "202", description = "Job ID for successfully scheduled Cassandra node decommission request",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,
@@ -47,6 +49,7 @@ public class NodeOpsResources {
     @POST
     @Path("/rebuild")
     @Operation(summary = "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.", operationId = "rebuild_v1")
+    @Produces(MediaType.TEXT_PLAIN)
     @ApiResponse(responseCode = "202", description = "Job ID for successfully scheduled Cassandra node rebuild request",
         content = @Content(
             mediaType = MediaType.TEXT_PLAIN,

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -4,10 +4,13 @@ import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -26,7 +29,13 @@ public class NodeOpsResources {
     @POST
     @Path("/decommission")
     @Operation(summary = "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.", operationId = "decommission_v1")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "202", description = "Job ID for successfully scheduled Cassandra node decommission request",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "34034d36-3c1e-4bdb-8a8f-f92291a64cb3")
+        )
+    )
     public Response decommission(@QueryParam(value="force")boolean force)
     {
         return com.datastax.mgmtapi.resources.NodeOpsResources.handle(() ->
@@ -38,7 +47,13 @@ public class NodeOpsResources {
     @POST
     @Path("/rebuild")
     @Operation(summary = "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.", operationId = "rebuild_v1")
-    @Produces(MediaType.TEXT_PLAIN)
+    @ApiResponse(responseCode = "202", description = "Job ID for successfully scheduled Cassandra node rebuild request",
+        content = @Content(
+            mediaType = MediaType.TEXT_PLAIN,
+            schema = @Schema(implementation = String.class),
+            examples = @ExampleObject(value = "34034d36-3c1e-4bdb-8a8f-f92291a64cb3")
+        )
+    )
     public Response rebuild(@QueryParam("src_dc") String srcDatacenter)
     {
         return com.datastax.mgmtapi.resources.NodeOpsResources.handle(() ->

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -25,7 +25,7 @@ public class NodeOpsResources {
 
     @POST
     @Path("/decommission")
-    @Operation(summary = "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.")
+    @Operation(summary = "Decommission the *node I am connecting to*. This invocation returns immediately and returns a job id.", operationId = "decommission_v1")
     @Produces(MediaType.TEXT_PLAIN)
     public Response decommission(@QueryParam(value="force")boolean force)
     {
@@ -37,7 +37,7 @@ public class NodeOpsResources {
 
     @POST
     @Path("/rebuild")
-    @Operation(summary = "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.")
+    @Operation(summary = "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id.", operationId = "rebuild_v1")
     @Produces(MediaType.TEXT_PLAIN)
     public Response rebuild(@QueryParam("src_dc") String srcDatacenter)
     {

--- a/management-api-server/src/main/resources/openapi-configuration.json
+++ b/management-api-server/src/main/resources/openapi-configuration.json
@@ -46,11 +46,41 @@
                         }
                     },
                     "responses": {
-                        "default": {
-                            "description": "default response",
+                        "200": {
                             "content": {
-                                "*/*": {}
-                            }
+                                "text/plain": {
+                                    "example": "OK",
+                                    "schema": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "description": "Cassandra configured successfully"
+                        },
+                        "400": {
+                            "content": {
+                                "text/plain": {
+                                    "example": "config missing",
+                                    "schema": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "description": "Cassandra configure request is missing required data or has invalid data"
+                        },
+                        "406": {
+                            "content": {
+                                "text/plain": {
+                                    "example": "Cassandra is running, try /api/v0/lifecycle/stop first",
+                                    "schema": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "description": "Cassandra can't be configured while running"
+                        },
+                        "500": {
+                            "description": "Error configuring Cassandra"
                         }
                     }
                 }

--- a/management-api-server/src/main/resources/openapi-configuration.json
+++ b/management-api-server/src/main/resources/openapi-configuration.json
@@ -2,7 +2,7 @@
     "resourcePackages": [
         "com.datastax.mgmtapi.resources"
     ],
-    "prettyPrint" : true,
+    "prettyPrint": true,
     "cacheTTL": 0,
     "openAPI": {
         "info": {
@@ -51,83 +51,6 @@
                             "content": {
                                 "*/*": {}
                             }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v0/ops/tables/create": {
-            "post": {
-                "summary": "Create a new table in an existing keyspace",
-                "operationId": "createTable",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateTableRequest"
-                            },
-                            "example": {
-                                "keyspace_name": "ks1",
-                                "table_name": "table1",
-                                "columns": [
-                                    {
-                                        "name": "pk1",
-                                        "type": "int",
-                                        "kind": "PARTITION_KEY",
-                                        "position": 0
-                                    },
-                                    {
-                                        "name": "pk2",
-                                        "type": "int",
-                                        "kind": "PARTITION_KEY",
-                                        "position": 1
-                                    },
-                                    {
-                                        "name": "cc1",
-                                        "type": "timeuuid",
-                                        "kind": "CLUSTERING",
-                                        "position": 0,
-                                        "order": "DESC"
-                                    },
-                                    {
-                                        "name": "cc2",
-                                        "type": "text",
-                                        "kind": "CLUSTERING",
-                                        "position": 1,
-                                        "order": "ASC"
-                                    },
-                                    {
-                                        "name": "v1",
-                                        "type": "timestamp",
-                                        "kind": "REGULAR"
-                                    },
-                                    {
-                                        "name": "v2",
-                                        "type": "list<text>",
-                                        "kind": "REGULAR"
-                                    },
-                                    {
-                                        "name": "s",
-                                        "type": "boolean",
-                                        "kind": "STATIC"
-                                    }
-                                ],
-                                "options": {
-                                    "bloom_filter_fp_chance": "0.01",
-                                    "caching": {
-                                        "keys": "ALL",
-                                        "rows_per_partition": "NONE"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "default": {
-                        "description": "default response",
-                        "content": {
-                            "text/plain": {}
                         }
                     }
                 }

--- a/management-api-server/src/main/resources/openapi-configuration.json
+++ b/management-api-server/src/main/resources/openapi-configuration.json
@@ -55,6 +55,83 @@
                     }
                 }
             }
+        },
+        "/api/v0/ops/tables/create": {
+            "post": {
+                "summary": "Create a new table in an existing keyspace",
+                "operationId": "createTable",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateTableRequest"
+                            },
+                            "example": {
+                                "keyspace_name": "ks1",
+                                "table_name": "table1",
+                                "columns": [
+                                    {
+                                        "name": "pk1",
+                                        "type": "int",
+                                        "kind": "PARTITION_KEY",
+                                        "position": 0
+                                    },
+                                    {
+                                        "name": "pk2",
+                                        "type": "int",
+                                        "kind": "PARTITION_KEY",
+                                        "position": 1
+                                    },
+                                    {
+                                        "name": "cc1",
+                                        "type": "timeuuid",
+                                        "kind": "CLUSTERING",
+                                        "position": 0,
+                                        "order": "DESC"
+                                    },
+                                    {
+                                        "name": "cc2",
+                                        "type": "text",
+                                        "kind": "CLUSTERING",
+                                        "position": 1,
+                                        "order": "ASC"
+                                    },
+                                    {
+                                        "name": "v1",
+                                        "type": "timestamp",
+                                        "kind": "REGULAR"
+                                    },
+                                    {
+                                        "name": "v2",
+                                        "type": "list<text>",
+                                        "kind": "REGULAR"
+                                    },
+                                    {
+                                        "name": "s",
+                                        "type": "boolean",
+                                        "kind": "STATIC"
+                                    }
+                                ],
+                                "options": {
+                                    "bloom_filter_fp_chance": "0.01",
+                                    "caching": {
+                                        "keys": "ALL",
+                                        "rows_per_partition": "NONE"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": "default response",
+                        "content": {
+                            "text/plain": {}
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/management-api-server/src/main/resources/openapi-configuration.json
+++ b/management-api-server/src/main/resources/openapi-configuration.json
@@ -13,6 +13,48 @@
                 "name": "Apache 2.0",
                 "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
             }
+        },
+        "paths": {
+            "/api/v0/lifecycle/configure": {
+                "post": {
+                    "description": "Configure Cassandra/DSE. Will fail if Cassandra/DSE is already started",
+                    "operationId": "configureNode",
+                    "parameters": [{
+                            "name": "profile",
+                            "in": "query",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "application/yaml": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "text/yaml": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "default": {
+                            "description": "default response",
+                            "content": {
+                                "*/*": {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #150

The Swagger maven plugin will generate the OepnAPI spec doc based on the actual JAX-RS code/annotations.

Tips:
The easiest way to review this is to:
1) Open the [old spec](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/k8ssandra/management-api-for-apache-cassandra/master/management-api-server/doc/openapi.json&nocors#operation/takeSnapshot) in a browser window
2) Open the [new spec](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/emerkle826/management-api-for-apache-cassandra/openapi-fixes/management-api-server/doc/openapi.json&nocors#operation/takeSnapshot) from this PR ina separate browser window
3) start at the top of the old spec browser and click on each of the endpoints, one at a time
4) for each endpoint in the old spec, find the same endpoint in the new spec and compare
