### PR TITLE
add endpoint to list schema versions, needed to check schema agreement

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -445,7 +445,7 @@ public class NodeOpsProvider
     @Rpc(name = "getSchemaVersions")
     public Map<String, List<String>> getSchemaVersions()
     {
-        return StorageProxy.describeSchemaVersions();
+        return StorageProxy.instance.getSchemaVersions();
     }
 
     @Rpc(name = "getKeyspaces")

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -442,6 +442,7 @@ public class NodeOpsProvider
         return ShimLoader.instance.get().getStreamInfo();
     }
 
+    @Rpc(name = "getSchemaVersions")
     public Map<String, List<String>> getSchemaVersions()
     {
         return StorageProxy.describeSchemaVersions();

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -33,6 +33,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -439,6 +440,11 @@ public class NodeOpsProvider
     public List<Map<String, List<Map<String, String>>>> getStreamInfo()
     {
         return ShimLoader.instance.get().getStreamInfo();
+    }
+
+    public Map<String, List<String>> getSchemaVersions()
+    {
+        return StorageProxy.describeSchemaVersions();
     }
 
     @Rpc(name = "getKeyspaces")

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -1514,6 +1514,11 @@
         "operationId" : "getSchemaVersions",
         "responses" : {
           "200" : {
+            "content" : {
+              "application/json" : {
+                "example" : "{2207c2a9-f598-3971-986b-2926e09e239d: [10.244.1.4, 10.244.2.3, 10.244.3.3]}"
+              }
+            },
             "description" : "Gets the schema versions for each node. Useful for checking schema agreement"
           }
         },

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -915,17 +915,6 @@
         "summary" : "Reset node's local schema and resync"
       }
     },
-    "/api/v0/ops/node/schema/versions" : {
-      "get" : {
-        "operationId" : "getSchemaVersions",
-        "responses" : {
-          "200" : {
-            "description" : "Gets the schema versions for each node. Useful for checking schema agreement"
-          }
-        },
-        "summary" : "Get schema versions."
-      }
-    },
     "/api/v0/ops/node/snapshots" : {
       "delete" : {
         "operationId" : "clearSnapshots",
@@ -1518,6 +1507,17 @@
           }
         },
         "summary" : "Rebuild data by streaming data from other nodes. This operation returns immediately with a job id."
+      }
+    },
+    "/api/v1/ops/node/schema/versions" : {
+      "get" : {
+        "operationId" : "getSchemaVersions",
+        "responses" : {
+          "200" : {
+            "description" : "Gets the schema versions for each node. Useful for checking schema agreement"
+          }
+        },
+        "summary" : "Get schema versions."
       }
     }
   },

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -915,6 +915,17 @@
         "summary" : "Reset node's local schema and resync"
       }
     },
+    "/api/v0/ops/node/schema/versions" : {
+      "get" : {
+        "operationId" : "getSchemaVersions",
+        "responses" : {
+          "200" : {
+            "description" : "Gets the schema versions for each node. Useful for checking schema agreement"
+          }
+        },
+        "summary" : "Get schema versions."
+      }
+    },
     "/api/v0/ops/node/snapshots" : {
       "delete" : {
         "operationId" : "clearSnapshots",

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -74,7 +74,12 @@ public class NodeOpsResources {
     @GET
     @Path("/schema/versions")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiResponse(responseCode = "200", description = "Gets the schema versions for each node. Useful for checking schema agreement")
+    @ApiResponse(
+            responseCode = "200",
+            description = "Gets the schema versions for each node. Useful for checking schema agreement",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    examples = @ExampleObject(value = "{2207c2a9-f598-3971-986b-2926e09e239d: [10.244.1.4, 10.244.2.3, 10.244.3.3]}")))
     @Operation(summary = "Get schema versions.", operationId = "getSchemaVersions")
     public Response schemaVersions()
     {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -4,6 +4,7 @@ import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -14,6 +15,10 @@ import javax.ws.rs.*;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
@@ -77,12 +82,12 @@ public class NodeOpsResources {
         {
             Row row = cqlService.executePreparedStatement(app.dbUnixSocketFile, "CALL NodeOps.getSchemaVersions()").one();
 
-            Object queryResponse = null;
+            Map<String, List> schemaVersions = Collections.emptyMap();
             if (row != null)
             {
-                queryResponse = row.getObject(0);
+                schemaVersions = row.getMap(0, String.class, List.class);
             }
-            return Response.ok(Entity.json(queryResponse)).build();
+            return Response.ok(schemaVersions).build();
         });
     }
 

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/NodeOpsResources.java
@@ -3,18 +3,19 @@ package com.datastax.mgmtapi.resources.v1;
 import com.datastax.mgmtapi.CqlService;
 import com.datastax.mgmtapi.ManagementApplication;
 import com.datastax.mgmtapi.resources.helpers.ResponseTools;
+import com.datastax.oss.driver.api.core.cql.Row;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import static com.datastax.mgmtapi.resources.NodeOpsResources.handle;
 
 @Path("/api/v1/ops/node")
 public class NodeOpsResources {
@@ -40,7 +41,7 @@ public class NodeOpsResources {
     )
     public Response decommission(@QueryParam(value="force")boolean force)
     {
-        return com.datastax.mgmtapi.resources.NodeOpsResources.handle(() ->
+        return handle(() ->
                 Response.accepted(
                         ResponseTools.getSingleRowStringResponse(app.dbUnixSocketFile, cqlService,"CALL NodeOps.decommission(?, ?)", force, true)
                         ).build());
@@ -59,10 +60,30 @@ public class NodeOpsResources {
     )
     public Response rebuild(@QueryParam("src_dc") String srcDatacenter)
     {
-        return com.datastax.mgmtapi.resources.NodeOpsResources.handle(() ->
+        return handle(() ->
                 Response.accepted(
                         ResponseTools.getSingleRowStringResponse(app.dbUnixSocketFile, cqlService, "CALL NodeOps.rebuild(?)", srcDatacenter)
                 ).build());
+    }
+
+    @GET
+    @Path("/schema/versions")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponse(responseCode = "200", description = "Gets the schema versions for each node. Useful for checking schema agreement")
+    @Operation(summary = "Get schema versions.", operationId = "getSchemaVersions")
+    public Response schemaVersions()
+    {
+        return handle(() ->
+        {
+            Row row = cqlService.executePreparedStatement(app.dbUnixSocketFile, "CALL NodeOps.getSchemaVersions()").one();
+
+            Object queryResponse = null;
+            if (row != null)
+            {
+                queryResponse = row.getObject(0);
+            }
+            return Response.ok(Entity.json(queryResponse)).build();
+        });
     }
 
 }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
@@ -550,7 +550,7 @@ public class NonDestructiveOpsIT extends BaseDockerIntegrationTest
 
         NettyHttpClient client = new NettyHttpClient(BASE_URL);
 
-        URIBuilder uriBuilder = new URIBuilder(BASE_PATH + "/ops/node/schema/versions");
+        URIBuilder uriBuilder = new URIBuilder("http://localhost:8080/api/v1/ops/node/schema/versions");
         URI uri = uriBuilder.build();
 
         Pair<Integer, String> response = client.get(uri.toURL()).thenApply(this::responseAsCodeAndBody).join();

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
@@ -563,11 +563,11 @@ public class NonDestructiveOpsIT extends BaseDockerIntegrationTest
         // The uuid is the schema version and list on the right are the nodes at that version. Because
         // are only testing with a single node we should expect the list to contain a single value.
 
-        Map<String, List<String>> actual = new JsonMapper().readValue(response.getRight(), new TypeReference<Map<String, List<String>>>(){});
+        Map<String, List> actual = new JsonMapper().readValue(response.getRight(), new TypeReference<Map<String, List>>(){});
         assertThat(actual).hasSizeGreaterThanOrEqualTo(1);
 
-        List<String> nodes = Lists.emptyList();
-        for (Map.Entry<String, List<String>> entry : actual.entrySet()) {
+        List nodes = Lists.emptyList();
+        for (Map.Entry<String, List> entry : actual.entrySet()) {
             nodes = entry.getValue();
             break;
         }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
@@ -20,7 +20,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.util.Lists;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -537,6 +540,39 @@ public class NonDestructiveOpsIT extends BaseDockerIntegrationTest
         List<String> keyspaces = jsonMapper.readValue(responseFilter, new TypeReference<List<String>>(){});
         assertEquals(1, keyspaces.size());
         assertEquals(ks, keyspaces.get(0));
+    }
+
+    @Test
+    public void testGetSchemaVersions() throws IOException, URISyntaxException
+    {
+        assumeTrue(IntegrationTestUtils.shouldRun());
+        ensureStarted();
+
+        NettyHttpClient client = new NettyHttpClient(BASE_URL);
+
+        URIBuilder uriBuilder = new URIBuilder(BASE_PATH + "/ops/node/schema/versions");
+        URI uri = uriBuilder.build();
+
+        Pair<Integer, String> response = client.get(uri.toURL()).thenApply(this::responseAsCodeAndBody).join();
+        assertThat(response.getLeft()).isEqualTo(HttpStatus.SC_OK);
+
+        // The response body should look something like this,
+        //
+        //    2207c2a9-f598-3971-986b-2926e09e239d: [10.244.1.4, 10.244.2.3, 10.244.3.3]
+        //
+        // The uuid is the schema version and list on the right are the nodes at that version. Because
+        // are only testing with a single node we should expect the list to contain a single value.
+
+        Map<String, List<String>> actual = new JsonMapper().readValue(response.getRight(), new TypeReference<Map<String, List<String>>>(){});
+        assertThat(actual).hasSizeGreaterThanOrEqualTo(1);
+
+        List<String> nodes = Lists.emptyList();
+        for (Map.Entry<String, List<String>> entry : actual.entrySet()) {
+            nodes = entry.getValue();
+            break;
+        }
+
+        assertThat(nodes.size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
We can already get schema versions from the `/metadata/endpoints` endpoint, but that's not entirely intuitive. I am adding an `/ops/node/schema/versions` endpoint which should be a bit simpler. It just delegates to `StorageProxy.describeSchemaVersions()` which is what `nodetool describecluster` does as well.