### PR TITLE
Prevent driver session initialization if socket file does not exist

### DIFF
--- a/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
@@ -84,6 +84,10 @@ public class UnixSocketCQLAccess
 
     public static Optional<CqlSession> get(File unixSocket)
     {
+        if (!unixSocket.exists()) {
+            logger.info("Cannot create Driver CQLSession as the driver socket has not been created. This should resolve once Cassandra has started and created the socket at {}", unixSocket.getAbsolutePath());
+            return Optional.empty();
+        }
         while (true)
         {
             UnixSocketCQLAccess client = cache.get(unixSocket);


### PR DESCRIPTION
This PR fixes an issue where driver session resources may leak if too many attempts to create a session fail because the Cassandra unix socket is not available.

Currently, when Management API starts up in Kubernetes, a readiness probe is executed until Management API is up and ready. While this is happening, logs similar to the following are emitted:
```
INFO  [epollEventLoopGroup-7-1] 2022-02-03 13:04:39,043 Clock.java:47 - Using native clock for microsecond precision
WARN  [epollEventLoopGroup-7-2] 2022-02-03 13:04:39,044 AbstractBootstrap.java:452 - Unknown channel option 'TCP_NODELAY' for channel '[id: 0x45d76dd8]'
WARN  [epollEventLoopGroup-7-2] 2022-02-03 13:04:39,048 Loggers.java:39 - [s2] Error connecting to Node(endPoint=/tmp/cassandra.sock, hostId=null, hashCode=6af4cf90), trying next node (FileNotFoundException: null)
INFO  [nioEventLoopGroup-2-1] 2022-02-03 13:04:39,050 Cli.java:617 - address=/172.17.0.1:44334 url=/api/v0/probes/readiness status=500 Internal Server Error
INFO  [epollEventLoopGroup-8-1] 2022-02-03 13:04:49,101 Clock.java:47 - Using native clock for microsecond precision
WARN  [epollEventLoopGroup-8-2] 2022-02-03 13:04:49,102 AbstractBootstrap.java:452 - Unknown channel option 'TCP_NODELAY' for channel '[id: 0x7b62ffab]'
WARN  [epollEventLoopGroup-8-2] 2022-02-03 13:04:49,104 Loggers.java:39 - [s3] Error connecting to Node(endPoint=/tmp/cassandra.sock, hostId=null, hashCode=51f97a72), trying next node (FileNotFoundException: null)
INFO  [nioEventLoopGroup-2-1] 2022-02-03 13:04:49,106 Cli.java:617 - address=/172.17.0.1:44334 url=/api/v0/probes/readiness status=500 Internal Server Error
INFO  [epollEventLoopGroup-9-1] 2022-02-03 13:04:59,126 Clock.java:47 - Using native clock for microsecond precision
WARN  [epollEventLoopGroup-9-2] 2022-02-03 13:04:59,127 AbstractBootstrap.java:452 - Unknown channel option 'TCP_NODELAY' for channel '[id: 0xfe6ab82e]'
WARN  [epollEventLoopGroup-9-2] 2022-02-03 13:04:59,129 Loggers.java:39 - [s4] Error connecting to Node(endPoint=/tmp/cassandra.sock, hostId=null, hashCode=5c52ca3f), trying next node (FileNotFoundException: null)
INFO  [nioEventLoopGroup-2-1] 2022-02-03 13:04:59,130 Cli.java:617 - address=/172.17.0.1:44334 url=/api/v0/probes/readiness status=500 Internal Server Error

```

With this PR, Management API won't even attempt to create a driver session if the unix socket is not available. So the same startup process will now have logs similar to this:
```
INFO  [nioEventLoopGroup-2-1] 2022-02-02 23:05:05,309 Cli.java:617 - address=/172.17.0.1:44314 url=/api/v0/probes/readiness status=500 Internal Server Error
INFO  [nioEventLoopGroup-3-2] 2022-02-02 23:05:15,312 UnixSocketCQLAccess.java:88 - Cannot create Driver CQLSession as the driver socket has not been created. This should resolve once Cassandra has started and created the socket at /tmp/cassandra.sock
INFO  [nioEventLoopGroup-2-1] 2022-02-02 23:05:15,314 Cli.java:617 - address=/172.17.0.1:44314 url=/api/v0/probes/readiness status=500 Internal Server Error
INFO  [nioEventLoopGroup-3-2] 2022-02-02 23:05:25,319 UnixSocketCQLAccess.java:88 - Cannot create Driver CQLSession as the driver socket has not been created. This should resolve once Cassandra has started and created the socket at /tmp/cassandra.sock
INFO  [nioEventLoopGroup-2-1] 2022-02-02 23:05:25,320 Cli.java:617 - address=/172.17.0.1:44314 url=/api/v0/probes/readiness status=500 Internal Server Error
INFO  [nioEventLoopGroup-3-2] 2022-02-02 23:05:35,325 UnixSocketCQLAccess.java:88 - Cannot create Driver CQLSession as the driver socket has not been created. This should resolve once Cassandra has started and created the socket at /tmp/cassandra.sock

```