### PR TITLE
Upgrade Cassandra versions to 3.11.12/4.0.3

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -41,30 +41,6 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           tags: '${{ env.RELEASE_VERSION }}'
           dockerfile: Dockerfile-dse-68
-  build-oss-4_0_1:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Setup Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-      - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
-      - name: Publish 4.0.1 to Registry
-        run: |
-          RELEASE_VERSION="${GITHUB_REF##*/}"
-          docker buildx build --push \
-            --build-arg CASSANDRA_VERSION=4.0.1 \
-            --tag k8ssandra/cass-management-api:4.0 \
-            --tag k8ssandra/cass-management-api:4.0.1 \
-            --tag k8ssandra/cass-management-api:4.0.1-$RELEASE_VERSION \
-            --file Dockerfile-4_0 \
-            --target oss40 \
-            --platform linux/amd64,linux/arm64 .
   build-oss-4_0_0:
     runs-on: ubuntu-latest
     steps:
@@ -85,6 +61,53 @@ jobs:
             --build-arg CASSANDRA_VERSION=4.0.0 \
             --tag k8ssandra/cass-management-api:4.0.0 \
             --tag k8ssandra/cass-management-api:4.0.0-$RELEASE_VERSION \
+            --file Dockerfile-4_0 \
+            --target oss40 \
+            --platform linux/amd64,linux/arm64 .
+  build-oss-4_0_1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+      - name: Publish 4.0.1 to Registry
+        run: |
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=4.0.1 \
+            --tag k8ssandra/cass-management-api:4.0.1 \
+            --tag k8ssandra/cass-management-api:4.0.1-$RELEASE_VERSION \
+            --file Dockerfile-4_0 \
+            --target oss40 \
+            --platform linux/amd64,linux/arm64 .
+  build-oss-4_0_2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+      - name: Publish 4.0.2 to Registry
+        run: |
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=4.0.2 \
+            --tag k8ssandra/cass-management-api:4.0 \
+            --tag k8ssandra/cass-management-api:4.0.2 \
+            --tag k8ssandra/cass-management-api:4.0.2-$RELEASE_VERSION \
             --file Dockerfile-4_0 \
             --target oss40 \
             --platform linux/amd64,linux/arm64 .
@@ -152,9 +175,32 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg CASSANDRA_VERSION=3.11.11 \
-            --tag k8ssandra/cass-management-api:3.11 \
             --tag k8ssandra/cass-management-api:3.11.11 \
             --tag k8ssandra/cass-management-api:3.11.11-$RELEASE_VERSION \
+            --file Dockerfile-oss \
+            --target oss311 \
+            --platform linux/amd64,linux/arm64 .
+  build-oss-3_11_12:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+      - name: Publish 3.11.12 to Registry
+        run: |
+          RELEASE_VERSION="${GITHUB_REF##*/}"
+          docker buildx build --push \
+            --build-arg CASSANDRA_VERSION=3.11.12 \
+            --tag k8ssandra/cass-management-api:3.11 \
+            --tag k8ssandra/cass-management-api:3.11.12 \
+            --tag k8ssandra/cass-management-api:3.11.12-$RELEASE_VERSION \
             --file Dockerfile-oss \
             --target oss311 \
             --platform linux/amd64,linux/arm64 .

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -87,7 +87,7 @@ jobs:
             --file Dockerfile-4_0 \
             --target oss40 \
             --platform linux/amd64,linux/arm64 .
-  build-oss-4_0_2:
+  build-oss-4_0_3:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -100,14 +100,14 @@ jobs:
           version: latest
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
-      - name: Publish 4.0.2 to Registry
+      - name: Publish 4.0.3 to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
-            --build-arg CASSANDRA_VERSION=4.0.2 \
+            --build-arg CASSANDRA_VERSION=4.0.3 \
             --tag k8ssandra/cass-management-api:4.0 \
-            --tag k8ssandra/cass-management-api:4.0.2 \
-            --tag k8ssandra/cass-management-api:4.0.2-$RELEASE_VERSION \
+            --tag k8ssandra/cass-management-api:4.0.3 \
+            --tag k8ssandra/cass-management-api:4.0.3-$RELEASE_VERSION \
             --file Dockerfile-4_0 \
             --target oss40 \
             --platform linux/amd64,linux/arm64 .

--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -1,4 +1,4 @@
-ARG CASSANDRA_VERSION=4.0.1
+ARG CASSANDRA_VERSION=4.0.2
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as builder
 

--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -1,4 +1,4 @@
-ARG CASSANDRA_VERSION=4.0.2
+ARG CASSANDRA_VERSION=4.0.3
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as builder
 

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -1,4 +1,4 @@
-ARG CASSANDRA_VERSION=3.11.11
+ARG CASSANDRA_VERSION=3.11.12
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as builder
 

--- a/management-api-agent-3.x/pom.xml
+++ b/management-api-agent-3.x/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>datastax-mgmtapi-agent-3.x</artifactId>
 
     <properties>
-        <cassandra3.version>3.11.11</cassandra3.version>
+        <cassandra3.version>3.11.12</cassandra3.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>

--- a/management-api-agent-4.x/pom.xml
+++ b/management-api-agent-4.x/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>datastax-mgmtapi-agent-4.x</artifactId>
 
     <properties>
-        <cassandra4.version>4.0.0</cassandra4.version>
+        <cassandra4.version>4.0.2</cassandra4.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>

--- a/management-api-agent-4.x/pom.xml
+++ b/management-api-agent-4.x/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>datastax-mgmtapi-agent-4.x</artifactId>
 
     <properties>
-        <cassandra4.version>4.0.2</cassandra4.version>
+        <cassandra4.version>4.0.3</cassandra4.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>

--- a/management-api-agent-common/pom.xml
+++ b/management-api-agent-common/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>datastax-mgmtapi-agent-common</artifactId>
 
     <properties>
-        <cassandra3.version>3.11.11</cassandra3.version>
+        <cassandra3.version>3.11.12</cassandra3.version>
         <bytebuddy.version>1.10.10</bytebuddy.version>
         <docker.java.version>3.1.5</docker.java.version>
         <build.version.file>build_version.sh</build.version.file>

--- a/management-api-common/pom.xml
+++ b/management-api-common/pom.xml
@@ -15,7 +15,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <netty.version>4.1.50.Final</netty.version>
-        <cassandra3.version>3.11.11</cassandra3.version>
+        <cassandra3.version>3.11.12</cassandra3.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.5.13</mockito.version>
     </properties>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -20,7 +20,7 @@
         <jaxrs.version>2.1.6</jaxrs.version>
         <resteasy.version>4.5.9.Final</resteasy.version>
         <netty.version>4.1.50.Final</netty.version>
-        <cassandra3.version>3.11.11</cassandra3.version>
+        <cassandra3.version>3.11.12</cassandra3.version>
         <docker.java.version>3.2.8</docker.java.version>
         <awaitility.version>4.0.3</awaitility.version>
         <assertj.version>3.17.2</assertj.version>


### PR DESCRIPTION
Once the new Cassandra versions are released and the DockerHub images published, we should be able to merge/tag this.

Fixes #178 
Fixes #179
Fixes #180 