### PR TITLE
Switch to using archive.apache instead of downloads.apache 

### DIFF
--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -196,7 +196,7 @@
                         <configuration>
                             <target unless="cassandra.bin.exists" >
                                 <mkdir dir=".cassandra-bin"/>
-                                <get src="https://downloads.apache.org/cassandra/${cassandra3.version}/apache-cassandra-${cassandra3.version}-bin.tar.gz"
+                                <get src="https://archive.apache.org/dist/cassandra/${cassandra3.version}/apache-cassandra-${cassandra3.version}-bin.tar.gz"
                                      dest=".cassandra-bin/"/>
                                 <untar src=".cassandra-bin/apache-cassandra-${cassandra3.version}-bin.tar.gz" dest=".cassandra-bin/"
                                        compression="gzip"/>


### PR DESCRIPTION
Switch to using archive.apache instead of downloads.apache for Cassandra 3 tests.

There is a particular test that requires a Cassandra 3 tarball and it currently sources it from a url on downloads.apache. These links roll over at every release (so that only the most recent version is available via that domain) which means we are unable to continue building images ourselves until we bump to the next version.

Links at the archive.apache domain are stable and should be preferred to ensure we can continue to build images in the time between when a new Cassandra version is released and when we choose to bump to the new version.