### PR TITLE
Use same path for CDC agent irrespective of C*/DSE version/agent version

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -37,7 +37,7 @@ RUN mkdir ${USER_HOME_PATH}
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
 
 FROM cassandra:${CASSANDRA_VERSION} as oss40
 

--- a/Dockerfile-dse-68
+++ b/Dockerfile-dse-68
@@ -32,7 +32,7 @@ RUN mvn -q -ff package -DskipTests -Pdse
 ENV CDC_AGENT_PATH /opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
 
 
 FROM datastax/dse-server:${CASSANDRA_VERSION}

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -34,7 +34,7 @@ RUN mkdir ${MCAC_PATH} && \
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
 
 ENV USER_HOME_PATH /home/cassandra
 RUN mkdir ${USER_HOME_PATH}


### PR DESCRIPTION
Moving CDC agent to /opt/cdc_agent/cdc-agent.jar for all agent versions and all C*/DSE versions. As requested by @emerkle826 and @burmanm.