### PR TITLE
Add GH Projects automation

### DIFF
--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,0 +1,16 @@
+name: Add issues to GH project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to GH project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/k8ssandra/projects/8
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}

--- a/.github/workflows/check_pr_linked_issue.yaml
+++ b/.github/workflows/check_pr_linked_issue.yaml
@@ -1,0 +1,14 @@
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check_pull_requests:
+    runs-on: ubuntu-latest
+    name: Check linked issues
+    steps:
+      - uses: nearform/github-action-check-linked-issues@v1
+        id: check-linked-issues
+        with:
+          exclude-branches: "dependabot/**"
+          comment: true


### PR DESCRIPTION
Add automation for GH projects:

- new issues get added to the board automatically
- PRs are checked for a linked issue (non blocking, just shows up in the check list)