### PR TITLE
Update ByteBuddy to 1.12.19

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
@@ -5,31 +5,28 @@
  */
 package com.datastax.mgmtapi.interceptors;
 
-import java.io.File;
-import java.nio.file.Paths;
-import java.util.concurrent.Callable;
-
-import com.google.common.collect.ImmutableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.datastax.mgmtapi.NodeOpsProvider;
 import com.datastax.mgmtapi.ShimLoader;
 import com.datastax.mgmtapi.ipc.IPCController;
-import com.datastax.mgmtapi.NodeOpsProvider;
+import com.google.common.collect.ImmutableMap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
 import org.apache.cassandra.transport.CBUtil;
 import org.apache.cassandra.transport.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
 
 public class CassandraDaemonInterceptor
 {
@@ -42,16 +39,10 @@ public class CassandraDaemonInterceptor
         return ElementMatchers.nameEndsWith(".CassandraDaemon");
     }
 
-    public static AgentBuilder.Transformer transformer()
+
+    public static Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("start")).intercept(MethodDelegation.to(CassandraDaemonInterceptor.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, module, protectionDomain) -> builder.method(ElementMatchers.named("start")).intercept(MethodDelegation.to(CassandraDaemonInterceptor.class));
     }
 
     public static void intercept(@SuperCall Callable<Void> zuper) throws Exception {
@@ -62,7 +53,6 @@ public class CassandraDaemonInterceptor
             logger.info("Starting DataStax Management API Agent for Apache Cassandra v0.1");
 
             NodeOpsProvider.instance.get().register();
-
 
             if (!Epoll.isAvailable())
                 throw new RuntimeException("Event loop needed");

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraRoleManagerInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraRoleManagerInterceptor.java
@@ -5,23 +5,20 @@
  */
 package com.datastax.mgmtapi.interceptors;
 
-import java.util.concurrent.Callable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.datastax.mgmtapi.ShimLoader;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
 import org.apache.cassandra.auth.AuthKeyspace;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Callable;
 
 public class CassandraRoleManagerInterceptor
 {
@@ -37,14 +34,7 @@ public class CassandraRoleManagerInterceptor
 
     public static AgentBuilder.Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("setupDefaultRole")).intercept(MethodDelegation.to(CassandraRoleManagerInterceptor.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, javaModule, protectionDomain) -> builder.method(ElementMatchers.named("setupDefaultRole")).intercept(MethodDelegation.to(CassandraRoleManagerInterceptor.class));
     }
 
     public static void intercept(@SuperCall Callable<Void> zuper) throws Exception

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/QueryHandlerInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/QueryHandlerInterceptor.java
@@ -5,17 +5,6 @@
  */
 package com.datastax.mgmtapi.interceptors;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.datastax.mgmtapi.NodeOpsProvider;
 import com.datastax.mgmtapi.ShimLoader;
 import com.datastax.mgmtapi.rpc.RpcMethod;
@@ -23,20 +12,28 @@ import com.datastax.mgmtapi.rpc.RpcRegistry;
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryHandler;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class QueryHandlerInterceptor
 {
@@ -51,14 +48,7 @@ public class QueryHandlerInterceptor
 
     public static AgentBuilder.Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("process")).intercept(MethodDelegation.to(QueryHandlerInterceptor.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, javaModule, protectionDomain) -> builder.method(ElementMatchers.named("process")).intercept(MethodDelegation.to(QueryHandlerInterceptor.class));
     }
 
     @RuntimeType

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/QueryHandlerInterceptor4x.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/QueryHandlerInterceptor4x.java
@@ -5,22 +5,20 @@
  */
 package com.datastax.mgmtapi.interceptors;
 
-import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
-
 import com.datastax.mgmtapi.ShimLoader;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.AllArguments;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
 import org.apache.cassandra.cql3.QueryHandler;
 import org.apache.cassandra.service.QueryState;
+
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
 
 import static com.datastax.mgmtapi.interceptors.QueryHandlerInterceptor.handlePrefix;
 import static com.datastax.mgmtapi.interceptors.QueryHandlerInterceptor.opsPattern;
@@ -34,14 +32,7 @@ public class QueryHandlerInterceptor4x
 
     public static AgentBuilder.Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("parse")).intercept(MethodDelegation.to(QueryHandlerInterceptor4x.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, javaModule, protectionDomain) -> builder.method(ElementMatchers.named("parse")).intercept(MethodDelegation.to(QueryHandlerInterceptor4x.class));
     }
 
     @RuntimeType

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/SystemDistributedReplicationInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/SystemDistributedReplicationInterceptor.java
@@ -5,6 +5,20 @@
  */
 package com.datastax.mgmtapi.interceptors;
 
+import com.google.common.collect.ImmutableMap;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.ReplicationParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -12,24 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import net.bytebuddy.agent.builder.AgentBuilder;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.implementation.MethodDelegation;
-import net.bytebuddy.implementation.bind.annotation.SuperCall;
-import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
-import org.apache.cassandra.locator.NetworkTopologyStrategy;
-import org.apache.cassandra.schema.KeyspaceMetadata;
-import org.apache.cassandra.schema.KeyspaceParams;
-import org.apache.cassandra.schema.ReplicationParams;
 
 import static net.bytebuddy.matcher.ElementMatchers.nameEndsWith;
 
@@ -152,14 +148,7 @@ public class SystemDistributedReplicationInterceptor
 
     public static AgentBuilder.Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("metadata")).intercept(MethodDelegation.to(SystemDistributedReplicationInterceptor.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, javaModule, protectionDomain) -> builder.method(ElementMatchers.named("metadata")).intercept(MethodDelegation.to(SystemDistributedReplicationInterceptor.class));
     }
 
     public static KeyspaceMetadata intercept(@SuperCall Callable<KeyspaceMetadata> zuper) throws Exception

--- a/management-api-agent-common/src/main/java/org/apache/cassandra/gms/GossiperInterceptor.java
+++ b/management-api-agent-common/src/main/java/org/apache/cassandra/gms/GossiperInterceptor.java
@@ -5,18 +5,15 @@
  */
 package org.apache.cassandra.gms;
 
-import java.util.concurrent.Callable;
-
-
 import com.datastax.mgmtapi.ShimLoader;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import net.bytebuddy.utility.JavaModule;
+
+import java.util.concurrent.Callable;
 
 public class GossiperInterceptor
 {
@@ -27,14 +24,7 @@ public class GossiperInterceptor
 
     public static AgentBuilder.Transformer transformer()
     {
-        return new AgentBuilder.Transformer()
-        {
-            @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule)
-            {
-                return builder.method(ElementMatchers.named("buildSeedList")).intercept(MethodDelegation.to(GossiperInterceptor.class));
-            }
-        };
+        return (builder, typeDescription, classLoader, javaModule, protectionDomain) -> builder.method(ElementMatchers.named("buildSeedList")).intercept(MethodDelegation.to(GossiperInterceptor.class));
     }
 
     public static void intercept(@SuperCall Callable<Void> zuper) throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <cassandra4.version>4.0.7</cassandra4.version>
         <docker.java.version>3.2.13</docker.java.version>
         <junit.version>4.13.2</junit.version>
-        <bytebuddy.version>1.10.10</bytebuddy.version>
+        <bytebuddy.version>1.12.19</bytebuddy.version>
         <build.version.file>build_version.sh</build.version.file>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.9</logback.version>


### PR DESCRIPTION
Updates ByteBuddy to 1.12.19. Started fine at least with Cassandra 4.0.6