### PR TITLE
Reorder the clean() and sanitizeMetricName in the metricName parser.

### DIFF
--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
@@ -79,12 +79,17 @@ public class CassandraMetricNameParser {
             labelValues.add(table);
         }
 
-        metricName = this.clean(Collector.sanitizeMetricName(metricName + suffix));
+        metricName = removeDoubleUnderscore(Collector.sanitizeMetricName(this.clean(metricName) + suffix));
 
         labelNames.addAll(additionalLabelNames);
         labelValues.addAll(additionalLabelValues);
 
         return new CassandraMetricDefinition(metricName, labelNames, labelValues);
+    }
+
+    private String removeDoubleUnderscore(String name) {
+        name = name.replaceAll("_+", "_");
+        return name;
     }
 
     // This is the method used in the MCAC

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsParsingTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsParsingTest.java
@@ -38,4 +38,12 @@ public class MetricsParsingTest {
                 .collect(Collectors.toMap(_i -> keyIter.next(), _i -> valIter.next()));
     }
 
+    @Test
+    public void parseWeirdNames() {
+        String dropwizardName = "com.datastax._weird_.constellation.schema$all*..__";
+        CassandraMetricNameParser parser = new CassandraMetricNameParser(Arrays.asList(""), Arrays.asList(""), new Configuration());
+        CassandraMetricDefinition metricDefinition = parser.parseDropwizardMetric(dropwizardName, "", new ArrayList<>(), new ArrayList<>());
+
+        assertEquals("com_datastax_weird_constellation_schema_all_", metricDefinition.getMetricName());
+    }
 }


### PR DESCRIPTION
Fixes #251 