### PR TITLE
Ignore when the CassandraVersion class isn't found to allow DSE to start

### DIFF
--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/interceptors/MetricsInterceptor.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/interceptors/MetricsInterceptor.java
@@ -25,7 +25,6 @@ public class MetricsInterceptor
 {
     private static final Logger logger = LoggerFactory.getLogger(MetricsInterceptor.class);
 
-    private static final CassandraVersion MIN_CASSANDRA_VERSION = new CassandraVersion("3.11.13");
 
     public static ElementMatcher<? super TypeDescription> type()
     {
@@ -38,10 +37,15 @@ public class MetricsInterceptor
     }
 
     public static void intercept(@SuperCall Callable<Void> zuper) throws Exception {
-        CassandraVersion cassandraVersion = new CassandraVersion(FBUtilities.getReleaseVersionString());
-        if(MIN_CASSANDRA_VERSION.compareTo(cassandraVersion) > 0) {
-            logger.error("/metrics endpoint is not supported in versions older than {}", MIN_CASSANDRA_VERSION);
-            return;
+        try{
+            final CassandraVersion minCassandraVersion = new CassandraVersion("3.11.13");
+            CassandraVersion cassandraVersion = new CassandraVersion(FBUtilities.getReleaseVersionString());
+            if(minCassandraVersion.compareTo(cassandraVersion) > 0) {
+                logger.error("/metrics endpoint is not supported in versions older than {}", minCassandraVersion);
+                return;
+            }
+        } catch (java.lang.NoClassDefFoundError expected) {
+            // We're dealing with DSE here and can safely ignore this
         }
 
         logger.info("Starting Metric Collector for Apache Cassandra");


### PR DESCRIPTION
The latest change makes DSE crash on startup because the CassandraVersion class doesn't exist there:

```
ERROR [DSE main thread] 2023-02-03 09:27:53,897  DseDaemon.java:564 - Unable to start DSE server.
java.lang.NoClassDefFoundError: org/apache/cassandra/utils/CassandraVersion
	at io.k8ssandra.metrics.interceptors.MetricsInterceptor.<clinit>(MetricsInterceptor.java:28)
	at org.apache.cassandra.service.CassandraDaemon.start(CassandraDaemon.java)
	at com.datastax.bdp.server.DseDaemon.start(DseDaemon.java:559)
	at org.apache.cassandra.service.CassandraDaemon.activate0(CassandraDaemon.java:809)
	at org.apache.cassandra.service.CassandraDaemon.access$100(CassandraDaemon.java:88)
	at org.apache.cassandra.service.CassandraDaemon$3.run(CassandraDaemon.java:717)
```

Since we don't need to check version on DSE (yet) we can safely ignore this exception.