### PR TITLE
Remove the use of set-output in GHA and upgrade actions using deprecated deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,7 +246,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/jar-release.yaml
+++ b/.github/workflows/jar-release.yaml
@@ -6,32 +6,8 @@ on:
       - 'v*.*.*'
 
 jobs:
-  create-release:
-    name: create release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Copy release URL into file
-        run: |
-          mkdir release
-          printf "%s" "${{ steps.create_release.outputs.upload_url }}" > release/url.txt
-      - name: Stash file containing the release URL as an artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: release-url
-          path: ./release
- 
-  build:
-    name: Build
+  build-and-release:
+    name: Build and release
     runs-on: ubuntu-latest
     steps:
 
@@ -63,20 +39,14 @@ jobs:
       - name: zip-up
         run: |
           zip jars.zip management-api-agent-common/target/datastax-mgmtapi-agent-*.jar management-api-agent-3.x/target/datastax-mgmtapi-agent-*.jar management-api-agent-4.x/target/datastax-mgmtapi-agent-*.jar management-api-agent-4.1.x/target/datastax-mgmtapi-agent-*.jar management-api-agent-dse-6.8/target/datastax-mgmtapi-agent-*.jar management-api-server/target/datastax-mgmtapi-server-*.jar management-api-common/target/datastax-mgmtapi-common-*.jar
-      - name: Retrieve stashed release URL
-        uses: actions/download-artifact@v1
-        with:
-          name: release-url
-      - name: Read release URL
-        id: get_release_url
-        run: echo ::set-output name=URL::$(cat release-url/url.txt)
 
-      - name: Upload jars 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          upload_url: ${{ steps.get_release_url.outputs.URL }}
-          asset_path: jars.zip
-          asset_name: jars.zip
-          asset_content_type: text/html
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Release ${{  github.ref_name }}
+          draft: false
+          prerelease: false
+          files: jars.zip
+


### PR DESCRIPTION
Fixes #247

The create-release and upload-artifacts actions aren't maintained anymore and I've switched to the recommended maintained actions. This simplifies the workflow as we can create the release and upload artifacts in a single step.
I've checked that the @actions/core dependency was at least 1.10.0 as indicated in [GH's blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Successfully tested this by tweaking the jar release workflow trigger to be `test*.*.*` instead of `v*.*.*`:
![Capture d’écran 2023-02-06 à 10 30 36](https://user-images.githubusercontent.com/5096002/216937720-1b52ba48-3db9-487c-9e65-68e6aafd7b22.png)

The release was created and the `jars.zip` artifact was successfully attached to it.
Here's the run output: https://github.com/k8ssandra/management-api-for-apache-cassandra/actions/runs/4102194244/jobs/7074849518
