### PR TITLE
Remove log that causes people to panic

### DIFF
--- a/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
@@ -78,7 +78,7 @@ public class UnixSocketCQLAccess {
 
   public static Optional<CqlSession> get(File unixSocket) {
     if (!unixSocket.exists()) {
-      logger.info(
+      logger.debug(
           "Cannot create Driver CQLSession as the driver socket has not been created. This should resolve once Cassandra has started and created the socket at {}",
           unixSocket.getAbsolutePath());
       return Optional.empty();


### PR DESCRIPTION
This technically makes the log that causes so much grief as reported in #189 a debug log, so it won't come out unless you change the default log level of Management API. So, technically it....
Fixes #189