### PR TITLE
Modify name parsing to do cleaning after every relabel rule

### DIFF
--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
@@ -82,8 +82,8 @@ public class CassandraMetricNameParser {
 
     // Reclean with suffix added
     metricDef.setMetricName(
-            removeDoubleUnderscore(
-                    Collector.sanitizeMetricName(this.clean(metricDef.getMetricName()) + suffix)));
+        removeDoubleUnderscore(
+            Collector.sanitizeMetricName(this.clean(metricDef.getMetricName()) + suffix)));
 
     return metricDef;
   }
@@ -134,8 +134,7 @@ public class CassandraMetricNameParser {
 
           if (relabel.getTargetLabel().equals(RelabelSpec.METRIC_NAME_LABELNAME)) {
             metricDefinition.setMetricName(
-                    removeDoubleUnderscore(
-                            Collector.sanitizeMetricName(this.clean(output))));
+                removeDoubleUnderscore(Collector.sanitizeMetricName(this.clean(output))));
           } else {
             // Not the most effective way of doing this (map would be better - but perf is not an
             // issue since this isn't done in the hotpath)

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
@@ -19,14 +19,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CassandraMetricNameParser {
-  public static final String KEYSPACE_METRIC_PREFIX = "org.apache.cassandra.metrics.keyspace.";
-  public static final String TABLE_METRIC_PREFIX = "org.apache.cassandra.metrics.Table.";
-
   private final List<String> defaultLabelNames;
   private final List<String> defaultLabelValues;
-
-  public static final String KEYSPACE_LABEL_NAME = "keyspace";
-  public static final String TABLE_LABEL_NAME = "table";
 
   private final List<RelabelSpec> replacements = new ArrayList<>();
 
@@ -76,7 +70,7 @@ public class CassandraMetricNameParser {
 
     String metricName =
         removeDoubleUnderscore(Collector.sanitizeMetricName(this.clean(dropwizardName)));
-    ;
+
     CassandraMetricDefinition metricDef =
         new CassandraMetricDefinition(metricName, labelNames, labelValues);
 
@@ -88,8 +82,8 @@ public class CassandraMetricNameParser {
 
     // Reclean with suffix added
     metricDef.setMetricName(
-        removeDoubleUnderscore(
-            Collector.sanitizeMetricName(this.clean(metricDef.getMetricName()) + suffix)));
+            removeDoubleUnderscore(
+                    Collector.sanitizeMetricName(this.clean(metricDef.getMetricName()) + suffix)));
 
     return metricDef;
   }
@@ -139,7 +133,9 @@ public class CassandraMetricNameParser {
           String output = inputMatcher.replaceAll(relabel.getReplacement());
 
           if (relabel.getTargetLabel().equals(RelabelSpec.METRIC_NAME_LABELNAME)) {
-            metricDefinition.setMetricName(output);
+            metricDefinition.setMetricName(
+                    removeDoubleUnderscore(
+                            Collector.sanitizeMetricName(this.clean(output))));
           } else {
             // Not the most effective way of doing this (map would be better - but perf is not an
             // issue since this isn't done in the hotpath)

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/relabel/RelabelSpec.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/relabel/RelabelSpec.java
@@ -93,4 +93,16 @@ public class RelabelSpec {
   public String getReplacement() {
     return replacement;
   }
+
+  @Override
+  public String toString() {
+    return "RelabelSpec{" +
+            "sourceLabels=" + sourceLabels +
+            ", targetLabel='" + targetLabel + '\'' +
+            ", replacement='" + replacement + '\'' +
+            ", separator='" + separator + '\'' +
+            ", regexp=" + regexp +
+            ", action=" + action +
+            '}';
+  }
 }

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/relabel/RelabelSpec.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/relabel/RelabelSpec.java
@@ -96,13 +96,22 @@ public class RelabelSpec {
 
   @Override
   public String toString() {
-    return "RelabelSpec{" +
-            "sourceLabels=" + sourceLabels +
-            ", targetLabel='" + targetLabel + '\'' +
-            ", replacement='" + replacement + '\'' +
-            ", separator='" + separator + '\'' +
-            ", regexp=" + regexp +
-            ", action=" + action +
-            '}';
+    return "RelabelSpec{"
+        + "sourceLabels="
+        + sourceLabels
+        + ", targetLabel='"
+        + targetLabel
+        + '\''
+        + ", replacement='"
+        + replacement
+        + '\''
+        + ", separator='"
+        + separator
+        + '\''
+        + ", regexp="
+        + regexp
+        + ", action="
+        + action
+        + '}';
   }
 }

--- a/management-api-agent-common/src/main/resources/default-metric-settings.yaml
+++ b/management-api-agent-common/src/main/resources/default-metric-settings.yaml
@@ -157,7 +157,7 @@ relabels:
   - regex: "jvm\\.memory\\.pools\\.(\\w+)\\.(\\w+)"
     replacement: jvm_memory_pools_$2
     sourceLabels:
-      - mcac
+      - __origname__
     targetLabel: __name__
 labels:
   env:

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsRegistryTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsRegistryTest.java
@@ -110,7 +110,7 @@ public class MetricsRegistryTest {
   public void timerTest() throws Exception {
     CassandraMetricsRegistry registry = CassandraMetricsRegistry.Metrics;
     Configuration config = new Configuration();
-    config.setRelabels(Arrays.asList(specDefault));
+//    config.setRelabels(Arrays.asList(specDefault));
     CassandraDropwizardExports exporter = new CassandraDropwizardExports(registry, config);
 
     Timer timer = registry.timer(createMetricName("test_timer"));

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsRegistryTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/MetricsRegistryTest.java
@@ -110,7 +110,7 @@ public class MetricsRegistryTest {
   public void timerTest() throws Exception {
     CassandraMetricsRegistry registry = CassandraMetricsRegistry.Metrics;
     Configuration config = new Configuration();
-//    config.setRelabels(Arrays.asList(specDefault));
+    //    config.setRelabels(Arrays.asList(specDefault));
     CassandraDropwizardExports exporter = new CassandraDropwizardExports(registry, config);
 
     Timer timer = registry.timer(createMetricName("test_timer"));

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
@@ -217,19 +217,16 @@ public class MultiFilterTest {
         new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "true");
 
     RelabelSpec addSecondTagValue =
-        new RelabelSpec(Lists.newArrayList("table"), "", "DroppedColumns", "", "should_drop", "false");
+        new RelabelSpec(
+            Lists.newArrayList("table"), "", "DroppedColumns", "", "should_drop", "false");
 
     RelabelSpec keepDroppedColumns =
-            new RelabelSpec(
-                    Lists.newArrayList("should_drop"),
-                    "",
-                    "true",
-                    "drop",
-                    "",
-                    "");
+        new RelabelSpec(Lists.newArrayList("should_drop"), "", "true", "drop", "", "");
 
     Configuration config = new Configuration();
-    config.setRelabels(Lists.newArrayList(tableExtractor, addFirstTagValue, addSecondTagValue, keepDroppedColumns));
+    config.setRelabels(
+        Lists.newArrayList(
+            tableExtractor, addFirstTagValue, addSecondTagValue, keepDroppedColumns));
     CassandraMetricNameParser parser =
         new CassandraMetricNameParser(Lists.newArrayList(), Lists.newArrayList(), config);
 
@@ -241,11 +238,11 @@ public class MultiFilterTest {
             Lists.newArrayList());
 
     CassandraMetricDefinition secondMetric =
-            parser.parseDropwizardMetric(
-                    "org.apache.cassandra.metrics.Table.MetricName.KeyspaceName.SeriouslyDroppedColumns",
-                    "",
-                    Lists.newArrayList(),
-                    Lists.newArrayList());
+        parser.parseDropwizardMetric(
+            "org.apache.cassandra.metrics.Table.MetricName.KeyspaceName.SeriouslyDroppedColumns",
+            "",
+            Lists.newArrayList(),
+            Lists.newArrayList());
 
     assertEquals(2, aMetric.getLabelValues().size());
     assertEquals(2, aMetric.getLabelNames().size());
@@ -266,21 +263,27 @@ public class MultiFilterTest {
     Configuration config = ConfigReader.readConfig();
 
     RelabelSpec dropAllTables =
-            new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "true");
+        new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "true");
 
     RelabelSpec spareMemTables =
-            new RelabelSpec(Lists.newArrayList("__name__"), "", "org_apache_cassandra_metrics_table_memtable.*", "", "should_drop", "false");
+        new RelabelSpec(
+            Lists.newArrayList("__name__"),
+            "",
+            "org_apache_cassandra_metrics_table_memtable.*",
+            "",
+            "should_drop",
+            "false");
 
     config.getRelabels().addAll(Lists.newArrayList(dropAllTables, spareMemTables));
     CassandraMetricNameParser parser =
-            new CassandraMetricNameParser(Lists.newArrayList(), Lists.newArrayList(), config);
+        new CassandraMetricNameParser(Lists.newArrayList(), Lists.newArrayList(), config);
 
     CassandraMetricDefinition aMetric =
-            parser.parseDropwizardMetric(
-                    "org.apache.cassandra.metrics.Table.MemtablePool_BlockedOnAllocation.system.peer_events",
-                    "",
-                    Lists.newArrayList(),
-                    Lists.newArrayList());
+        parser.parseDropwizardMetric(
+            "org.apache.cassandra.metrics.Table.MemtablePool_BlockedOnAllocation.system.peer_events",
+            "",
+            Lists.newArrayList(),
+            Lists.newArrayList());
 
     assertEquals("should_drop", aMetric.getLabelNames().get(aMetric.getLabelNames().size() - 1));
     assertEquals("false", aMetric.getLabelValues().get(aMetric.getLabelValues().size() - 1));

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.Lists;
 import io.k8ssandra.metrics.builder.CassandraMetricDefinition;
 import io.k8ssandra.metrics.builder.CassandraMetricNameParser;
+import io.k8ssandra.metrics.config.ConfigReader;
 import io.k8ssandra.metrics.config.Configuration;
 import java.util.ArrayList;
 import java.util.List;
@@ -216,10 +217,19 @@ public class MultiFilterTest {
         new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "true");
 
     RelabelSpec addSecondTagValue =
-        new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "false");
+        new RelabelSpec(Lists.newArrayList("table"), "", "DroppedColumns", "", "should_drop", "false");
+
+    RelabelSpec keepDroppedColumns =
+            new RelabelSpec(
+                    Lists.newArrayList("should_drop"),
+                    "",
+                    "true",
+                    "drop",
+                    "",
+                    "");
 
     Configuration config = new Configuration();
-    config.setRelabels(Lists.newArrayList(tableExtractor, addFirstTagValue, addSecondTagValue));
+    config.setRelabels(Lists.newArrayList(tableExtractor, addFirstTagValue, addSecondTagValue, keepDroppedColumns));
     CassandraMetricNameParser parser =
         new CassandraMetricNameParser(Lists.newArrayList(), Lists.newArrayList(), config);
 
@@ -230,11 +240,49 @@ public class MultiFilterTest {
             Lists.newArrayList(),
             Lists.newArrayList());
 
+    CassandraMetricDefinition secondMetric =
+            parser.parseDropwizardMetric(
+                    "org.apache.cassandra.metrics.Table.MetricName.KeyspaceName.SeriouslyDroppedColumns",
+                    "",
+                    Lists.newArrayList(),
+                    Lists.newArrayList());
+
     assertEquals(2, aMetric.getLabelValues().size());
     assertEquals(2, aMetric.getLabelNames().size());
 
     assertEquals("table", aMetric.getLabelNames().get(0));
     assertEquals("should_drop", aMetric.getLabelNames().get(1));
     assertEquals("false", aMetric.getLabelValues().get(1));
+
+    assertEquals("true", secondMetric.getLabelValues().get(1));
+
+    assertTrue(aMetric.isKeep());
+    assertFalse(secondMetric.isKeep());
+  }
+
+  @Test
+  public void shouldDropTest() {
+    // This reads the default relabeling rules for Cassandra also
+    Configuration config = ConfigReader.readConfig();
+
+    RelabelSpec dropAllTables =
+            new RelabelSpec(Lists.newArrayList("table"), "", ".+", "", "should_drop", "true");
+
+    RelabelSpec spareMemTables =
+            new RelabelSpec(Lists.newArrayList("__name__"), "", "org_apache_cassandra_metrics_table_memtable.*", "", "should_drop", "false");
+
+    config.getRelabels().addAll(Lists.newArrayList(dropAllTables, spareMemTables));
+    CassandraMetricNameParser parser =
+            new CassandraMetricNameParser(Lists.newArrayList(), Lists.newArrayList(), config);
+
+    CassandraMetricDefinition aMetric =
+            parser.parseDropwizardMetric(
+                    "org.apache.cassandra.metrics.Table.MemtablePool_BlockedOnAllocation.system.peer_events",
+                    "",
+                    Lists.newArrayList(),
+                    Lists.newArrayList());
+
+    assertEquals("should_drop", aMetric.getLabelNames().get(aMetric.getLabelNames().size() - 1));
+    assertEquals("false", aMetric.getLabelValues().get(aMetric.getLabelValues().size() - 1));
   }
 }

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/config/ConfigReaderTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/config/ConfigReaderTest.java
@@ -59,4 +59,16 @@ public class ConfigReaderTest {
     assertEquals("/etc/ssl/tls.crt", tlsConfig.getTlsCertPath());
     assertEquals("/etc/ssl/tls.key", tlsConfig.getTlsKeyPath());
   }
+
+  @Test
+  public void verifyCustomRelabelRulesAreAppended() {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    URL resource = classLoader.getResource("collector_tls.yaml");
+
+    System.setProperty(ConfigReader.CONFIG_PATH_PROPERTY, resource.getFile());
+    Configuration configuration = ConfigReader.readConfig();
+    assertEquals(30, configuration.getRelabels().size());
+    assertEquals("(.*);(b.*)", configuration.getRelabels().get(28).getRegexp().toString());
+    assertEquals("^(a|b|c),.*", configuration.getRelabels().get(29).getRegexp().toString());
+  }
 }


### PR DESCRIPTION
If the relabel rule modifies the _name__ field, clean it at that point also, instead of only at the end. Also, fix one bug in the default-metrics-settings for JVM relabel rule and add some additional tests

@Miles-Garnsey 