### PR TITLE
Fix file ownership and permissions in images

### DIFF
--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -26,7 +26,7 @@ COPY management-api-agent-4.x ./management-api-agent-4.x
 COPY management-api-agent-4.1.x ./management-api-agent-4.1.x
 COPY management-api-common ./management-api-common
 COPY management-api-server ./management-api-server
-RUN mkdir ${MAAC_PATH} && \
+RUN mkdir -m 775 ${MAAC_PATH} && \
     mvn -q -ff package -DskipTests && \
     find /build -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + && \
     rm $MAAC_PATH/datastax-mgmtapi-agent-3* && \
@@ -39,16 +39,16 @@ RUN mkdir ${MAAC_PATH} && \
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
-RUN mkdir ${MCAC_PATH} && \
+RUN mkdir -m 775 ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
     tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
     chmod -R g+w ${MCAC_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
+RUN mkdir -m 775 ${USER_HOME_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -103,7 +103,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra:root
+USER cassandra
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/Dockerfile-4_0
+++ b/Dockerfile-4_0
@@ -34,21 +34,24 @@ RUN mkdir ${MAAC_PATH} && \
     cd ${MAAC_PATH} && \
     ln -s datastax-mgmtapi-agent-4.x-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar && \
     ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar && \
-    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
 RUN mkdir ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
-    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz
+    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
+    chmod -R g+w ${MCAC_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH}
+RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 FROM cassandra:${CASSANDRA_VERSION} as oss40
 
@@ -74,7 +77,10 @@ COPY --from=builder --chown=cassandra:root ${USER_HOME_PATH} ${USER_HOME_PATH}
 COPY --from=builder --chown=cassandra:root ${CDC_AGENT_PATH} ${CDC_AGENT_PATH}
 
 # Setup user and fixup permissions
-RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH}
+RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH} && \
+    # we don't need recursive chnages here because the files in the directories already have group write
+    chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} ${CDC_AGENT_PATH}
+
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
@@ -97,7 +103,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra
+USER cassandra:root
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/Dockerfile-4_1
+++ b/Dockerfile-4_1
@@ -35,21 +35,24 @@ RUN mkdir ${MAAC_PATH} && \
     cd ${MAAC_PATH} && \
     ln -s datastax-mgmtapi-agent-4.1.x-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar && \
     ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar && \
-    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
 RUN mkdir ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz"; fi && \
-    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz
+    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz && \
+    chmod -R g+w ${MCAC_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH}
+RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 FROM cassandra:${CASSANDRA_VERSION} as oss41
 
@@ -75,7 +78,9 @@ COPY --from=builder --chown=cassandra:root ${USER_HOME_PATH} ${USER_HOME_PATH}
 COPY --from=builder --chown=cassandra:root ${CDC_AGENT_PATH} ${CDC_AGENT_PATH}
 
 # Setup user and fixup permissions
-RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH}
+RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH} && \
+    # we don't need recursive chnages here because the files in the directories already have group write
+    chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} ${CDC_AGENT_PATH}
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
@@ -98,7 +103,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra
+USER cassandra:root
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/Dockerfile-4_1
+++ b/Dockerfile-4_1
@@ -27,7 +27,7 @@ COPY management-api-agent-4.x ./management-api-agent-4.x
 COPY management-api-agent-4.1.x ./management-api-agent-4.1.x
 COPY management-api-common ./management-api-common
 COPY management-api-server ./management-api-server
-RUN mkdir ${MAAC_PATH} && \
+RUN mkdir -m 775 ${MAAC_PATH} && \
     mvn -q -ff package -DskipTests && \
     find /build -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + && \
     rm $MAAC_PATH/datastax-mgmtapi-agent-3* && \
@@ -40,16 +40,16 @@ RUN mkdir ${MAAC_PATH} && \
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
-RUN mkdir ${MCAC_PATH} && \
+RUN mkdir -m 775 ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz"; fi && \
     tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_BUNDLE}.tar.gz && \
     chmod -R g+w ${MCAC_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
+RUN mkdir -m 775 ${USER_HOME_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -103,7 +103,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra:root
+USER cassandra
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -34,21 +34,24 @@ RUN mkdir ${MAAC_PATH} && \
     cd ${MAAC_PATH} && \
     ln -s datastax-mgmtapi-agent-3.x-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar && \
     ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar && \
-    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
 RUN mkdir ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
-    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz
+    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
+    chmod -R g+w ${MCAC_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH}
+RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
 RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
@@ -85,7 +88,10 @@ COPY --from=builder --chown=cassandra:root ${USER_HOME_PATH} ${USER_HOME_PATH}
 COPY --from=builder --chown=cassandra:root ${CDC_AGENT_PATH} ${CDC_AGENT_PATH}
 
 # Setup user and fixup permissions
-RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH}
+RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH} && \
+    # we don't need recursive chnages here because the files in the directories already have group write
+    chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} ${CDC_AGENT_PATH}
+
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
@@ -107,7 +113,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra
+USER cassandra:root
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -51,7 +51,7 @@ RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   chmod -R g+w ${CDC_AGENT_PATH}
 
 ENV USER_HOME_PATH /home/cassandra
-RUN mkdir ${USER_HOME_PATH} && chmod -R g+w ${USER_HOME_PATH}
+RUN mkdir -m 775 ${USER_HOME_PATH}
 
 FROM --platform=$BUILDPLATFORM maven:3.6.3-jdk-8-slim as netty4150
 RUN mvn dependency:get -DgroupId=io.netty -DartifactId=netty-all -Dversion=4.1.50.Final -Dtransitive=false
@@ -62,7 +62,7 @@ FROM --platform=linux/arm64 cassandra:${CASSANDRA_VERSION} as oss311-arm64
 # Netty arm64 epoll support was not added until 4.1.50 (https://github.com/netty/netty/pull/9804)
 # Only replace this dependency for arm64 to avoid regressions
 RUN rm /opt/cassandra/lib/netty-all-*.jar
-COPY --from=netty4150 /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
+COPY --from=netty4150 --chown=cassandra:root /root/.m2/repository/io/netty/netty-all/4.1.50.Final/netty-all-4.1.50.Final.jar /opt/cassandra/lib/netty-all-4.1.50.Final.jar
 
 FROM oss311-${TARGETARCH} as oss311
 

--- a/Dockerfile-oss
+++ b/Dockerfile-oss
@@ -26,7 +26,7 @@ COPY management-api-agent-4.x ./management-api-agent-4.x
 COPY management-api-agent-4.1.x ./management-api-agent-4.1.x
 COPY management-api-common ./management-api-common
 COPY management-api-server ./management-api-server
-RUN mkdir ${MAAC_PATH} && \
+RUN mkdir -m 775 ${MAAC_PATH} && \
     mvn -q -ff package -DskipTests && \
     find /build -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + && \
     rm $MAAC_PATH/datastax-mgmtapi-agent-4* && \
@@ -39,13 +39,13 @@ RUN mkdir ${MAAC_PATH} && \
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
-RUN mkdir ${MCAC_PATH} && \
+RUN mkdir -m 775 ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
     tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
     chmod -R g+w ${MCAC_PATH}
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -92,7 +92,6 @@ RUN chown -R cassandra:root ${CASSANDRA_PATH} && chmod -R g+w ${CASSANDRA_PATH} 
     # we don't need recursive chnages here because the files in the directories already have group write
     chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${USER_HOME_PATH} ${CDC_AGENT_PATH}
 
-
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
@@ -113,7 +112,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
 EXPOSE 9103 9000
 EXPOSE 8080
 
-USER cassandra:root
+USER cassandra
 
 ENTRYPOINT ["/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["mgmtapi"]

--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ Cassandra 4.1.x
       k8ssandra/cass-management-api:4.1.1
       k8ssandra/cass-management-api:4.1.2
 
-Cassandra trunk
+Cassandra trunk (currently, these are nightly builds)
 
-      k8ssandra/cass-management-api:4.2.0
+      k8ssandra/cass-management-api:5.0-nightly-latest or
+      k8ssandra/cass-management-api:5.0-nightly-YYYYMMDD
 
 DSE 6.8.x
 

--- a/cassandra-trunk/Dockerfile.ubi8
+++ b/cassandra-trunk/Dockerfile.ubi8
@@ -21,7 +21,7 @@ WORKDIR /
 
 # Download and extract Metrics Collector
 ENV MCAC_PATH /opt/metrics-collector
-RUN mkdir ${MCAC_PATH} && \
+RUN mkdir -m 775 ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-{METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
     tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
     chmod -R g+w ${MCAC_PATH}
@@ -37,7 +37,6 @@ RUN if test ! -e tini-amd64; then curl -L -O "https://github.com/krallin/tini/re
 FROM --platform=$BUILDPLATFORM azul/zulu-openjdk-debian:11 as cass-builder
 ARG COMMITSHA="HEAD"
 ENV CASSANDRA_PATH /opt/cassandra
-ENV CASSANDRA_FILES_PATH /opt/cassandra_files
 WORKDIR /build
 RUN set -x \
     && rm -fr /etc/apt/sources.list.d/* \
@@ -49,7 +48,7 @@ RUN set -x \
     && git checkout $(git rev-parse --short ${COMMITSHA}) \
     #&& ant -q -S echo-base-version > /build/cassandra.version \
     && ant artifacts mvn-install -Duse.jdk11=true \
-    && mkdir ${CASSANDRA_PATH} ${CASSANDRA_FILES_PATH} \
+    && mkdir -m 775 ${CASSANDRA_PATH} ${CASSANDRA_FILES_PATH} \
     && tar --directory ${CASSANDRA_PATH} --strip-components 1 --gzip --extract --file /build/cassandra/build/apache-cassandra-5.0-SNAPSHOT-bin.tar.gz \
     && rm -rf ${CASSANDRA_PATH}/javadoc ${CASSANDRA_PATH}/doc \
     && chmod -R g+w ${CASSANDRA_PATH}
@@ -85,7 +84,7 @@ COPY management-api-agent-4.1.x /tmp/management-api-agent-4.1.x
 COPY management-api-agent-5.0.x /tmp/management-api-agent-5.0.x
 COPY management-api-common /tmp/management-api-common
 COPY management-api-server /tmp/management-api-server
-RUN mkdir $MAAC_PATH \
+RUN mkdir -m 775 $MAAC_PATH \
     && cd /tmp \
     && mvn -q -ff package -DskipTests -P trunk \
     && find /tmp -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + \
@@ -106,7 +105,7 @@ ARG CDC_AGENT_VERSION=2.2.9
 ARG CDC_AGENT_EDITION=agent-c4
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -172,10 +171,10 @@ RUN (for dir in /var/lib/cassandra \
     done ) && \
     touch config/foo && \
     # change mode of directories
-    chmod 775 ${MAAC_PATH} ${MCAC_PATH} ${CASSANDRA_PATH} ${CDC_AGENT_PATH}
+    chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${CASSANDRA_PATH} ${CDC_AGENT_PATH}
 
 # Set user to run as
-USER cassandra:root
+USER cassandra:cassandra
 
 # Expose CASSANDRA folders
 VOLUME ["/config", "/var/lib/cassandra", "/var/log/cassandra"]

--- a/cassandra-trunk/Dockerfile.ubi8
+++ b/cassandra-trunk/Dockerfile.ubi8
@@ -23,7 +23,8 @@ WORKDIR /
 ENV MCAC_PATH /opt/metrics-collector
 RUN mkdir ${MCAC_PATH} && \
     if test ! -e datastax-mcac-agent-{METRICS_COLLECTOR_VERSION}.tar.gz; then curl -L -O "https://github.com/datastax/metric-collector-for-apache-cassandra/releases/download/v${METRICS_COLLECTOR_VERSION}/datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz"; fi && \
-    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz
+    tar --directory ${MCAC_PATH} --strip-components 1 --gzip --extract --file datastax-mcac-agent-${METRICS_COLLECTOR_VERSION}.tar.gz && \
+    chmod -R g+w ${MCAC_PATH}
 
 # Install tini
 RUN if test ! -e tini-amd64; then curl -L -O "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-amd64"; fi && \
@@ -36,6 +37,7 @@ RUN if test ! -e tini-amd64; then curl -L -O "https://github.com/krallin/tini/re
 FROM --platform=$BUILDPLATFORM azul/zulu-openjdk-debian:11 as cass-builder
 ARG COMMITSHA="HEAD"
 ENV CASSANDRA_PATH /opt/cassandra
+ENV CASSANDRA_FILES_PATH /opt/cassandra_files
 WORKDIR /build
 RUN set -x \
     && rm -fr /etc/apt/sources.list.d/* \
@@ -47,9 +49,11 @@ RUN set -x \
     && git checkout $(git rev-parse --short ${COMMITSHA}) \
     #&& ant -q -S echo-base-version > /build/cassandra.version \
     && ant artifacts mvn-install -Duse.jdk11=true \
-    && mkdir ${CASSANDRA_PATH} \
+    && mkdir ${CASSANDRA_PATH} ${CASSANDRA_FILES_PATH} \
     && tar --directory ${CASSANDRA_PATH} --strip-components 1 --gzip --extract --file /build/cassandra/build/apache-cassandra-5.0-SNAPSHOT-bin.tar.gz \
-    && rm -rf ${CASSANDRA_PATH}/javadoc ${CASSANDRA_PATH}/doc
+    && rm -rf ${CASSANDRA_PATH}/javadoc ${CASSANDRA_PATH}/doc \
+    && chmod -R g+w ${CASSANDRA_PATH}
+COPY cassandra-trunk/files ${CASSANDRA_FILES_PATH}
 
 #############################################################
 # Build the Management API
@@ -92,7 +96,8 @@ RUN mkdir $MAAC_PATH \
     && cd ${MAAC_PATH} \
     && ln -s datastax-mgmtapi-agent-5.0.x-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar \
     && ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar \
-    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 
 ###
 # Download CDC Agent jarfile
@@ -103,7 +108,8 @@ ARG CDC_AGENT_EDITION=agent-c4
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 ############################################################
 
@@ -112,7 +118,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:${BASETAG} as cass-trunk
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="Apache Cassandra"
 LABEL vendor="DataStax, Inc"
-LABEL release="4.2-SNAPSHOT"
+LABEL release="5.0-SNAPSHOT"
 LABEL summary="Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients."
 LABEL description="Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients."
 
@@ -128,6 +134,8 @@ ENV CASSANDRA_HOME ${CASSANDRA_PATH}
 ENV CASSANDRA_CONF ${CASSANDRA_PATH}/conf
 ENV CASSANDRA_LOG_DIR /var/log/cassandra
 
+ENV CASSANDRA_FILES_PATH /opt/cassandra_files
+
 # Update base layer
 RUN microdnf update && rm -rf /var/cache/yum \
 # Install packages needed during install process
@@ -135,7 +143,7 @@ RUN microdnf update && rm -rf /var/cache/yum \
     && microdnf clean all \
 # Add Cassandra user
     && groupadd -r cassandra --gid=998 \
-    && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra
+    && useradd -m -d "$CASSANDRA_HOME" -r -g root -G cassandra --uid=999 cassandra
 
 # Copy user accounts information
 #COPY --from=builder /etc/passwd /etc/passwd
@@ -150,7 +158,7 @@ COPY --from=builder --chown=cassandra:root ${MCAC_PATH} ${MCAC_PATH}
 COPY --from=builder /usr/local/bin/tini /usr/local/bin/tini
 COPY --from=mgmtapi-setup --chown=cassandra:root ${MAAC_PATH} ${MAAC_PATH}
 COPY --from=mgmtapi-setup --chown=cassandra:root $CDC_AGENT_PATH $CDC_AGENT_PATH
-COPY --chown=cassandra:root cassandra-trunk/files /
+COPY --from=cass-builder --chown=cassandra:root ${CASSANDRA_FILES_PATH} /
 
 # Fix permissions
 #RUN chown -R cassandra:root ${CASSANDRA_PATH} ${MAAC_PATH} ${MCAC_PATH} && \
@@ -162,10 +170,12 @@ RUN (for dir in /var/lib/cassandra \
                 /config ; do \
         mkdir -p $dir && chown -R cassandra:root $dir && chmod 775 $dir ; \
     done ) && \
-    touch config/foo
+    touch config/foo && \
+    # change mode of directories
+    chmod 775 ${MAAC_PATH} ${MCAC_PATH} ${CASSANDRA_PATH} ${CDC_AGENT_PATH}
 
 # Set user to run as
-USER cassandra:cassandra
+USER cassandra:root
 
 # Expose CASSANDRA folders
 VOLUME ["/config", "/var/lib/cassandra", "/var/log/cassandra"]

--- a/cassandra-trunk/Dockerfile.ubi8
+++ b/cassandra-trunk/Dockerfile.ubi8
@@ -37,6 +37,7 @@ RUN if test ! -e tini-amd64; then curl -L -O "https://github.com/krallin/tini/re
 FROM --platform=$BUILDPLATFORM azul/zulu-openjdk-debian:11 as cass-builder
 ARG COMMITSHA="HEAD"
 ENV CASSANDRA_PATH /opt/cassandra
+ENV CASSANDRA_FILES_PATH /opt/cassandra_files
 WORKDIR /build
 RUN set -x \
     && rm -fr /etc/apt/sources.list.d/* \

--- a/dse-68/Dockerfile.jdk11
+++ b/dse-68/Dockerfile.jdk11
@@ -36,7 +36,8 @@ RUN set -x \
 # Use hard links to reduce the size impact of duplicate jars
     && apt-get update \
     && apt-get install -y --install-recommends rdfind \
-    && rdfind -makehardlinks true -makeresultsfile false ${DSE_HOME}
+    && rdfind -makehardlinks true -makeresultsfile false ${DSE_HOME} \
+    && chmod -R g+w ${DSE_HOME} ${DSE_AGENT_HOME}
 
 #############################################################
 
@@ -99,7 +100,7 @@ COPY management-api-agent-4.1.x /tmp/management-api-agent-4.1.x
 COPY management-api-agent-dse-6.8 /tmp/management-api-agent-dse-6.8
 COPY management-api-common /tmp/management-api-common
 COPY management-api-server /tmp/management-api-server
-RUN mkdir $MAAC_PATH \
+RUN mkdir -m 775 $MAAC_PATH \
     && cd /tmp \
     && mvn -q -ff package -DskipTests -P dse \
     && find /tmp -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + \
@@ -120,7 +121,7 @@ ARG CDC_AGENT_VERSION=2.2.9
 ARG CDC_AGENT_EDITION=agent-dse4
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -130,7 +131,7 @@ FROM datastax/${DS_BASE_DEBIAN}:${BASETAG} AS dse68
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="dse-server"
 LABEL vendor="DataStax, Inc"
-LABEL release="6.8.26"
+LABEL release="6.8.36"
 
 ENV DSE_HOME /opt/dse
 ENV DSE_AGENT_HOME /opt/agent
@@ -171,11 +172,14 @@ COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
+# Fix COPY directory modes
+RUN chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
+
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME
 WORKDIR $HOME
 
-USER dse:root
+USER dse
 
 # Expose DSE folders
 VOLUME ["/var/lib/cassandra", "/var/lib/spark", "/var/lib/dsefs", "/var/log/cassandra", "/var/log/spark"]

--- a/dse-68/Dockerfile.jdk11
+++ b/dse-68/Dockerfile.jdk11
@@ -15,7 +15,7 @@ ARG URL_PREFIX=https://downloads.datastax.com/enterprise
 ARG TARBALL=dse-${DSE_VERSION}-bin.tar.gz
 ARG DOWNLOAD_URL=${URL_PREFIX}/${TARBALL}
 
-ARG DSE_AGENT_VERSION=6.8.24
+ARG DSE_AGENT_VERSION=6.8.26
 ARG DSE_AGENT_TARBALL=datastax-agent-${DSE_AGENT_VERSION}.tar.gz
 ARG DSE_AGENT_DOWNLOAD_URL=${URL_PREFIX}/${DSE_AGENT_TARBALL}
 
@@ -109,7 +109,8 @@ RUN mkdir $MAAC_PATH \
     && cd ${MAAC_PATH} \
     && ln -s datastax-mgmtapi-agent-dse-6.8-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar \
     && ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar \
-    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 #############################################################
 
 ###
@@ -121,7 +122,8 @@ ARG CDC_AGENT_EDITION=agent-dse4
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 FROM datastax/${DS_BASE_DEBIAN}:${BASETAG} AS dse68
 
@@ -148,8 +150,8 @@ RUN set -x \
 
 COPY dse-68/files /
 
-COPY --chown=dse:dse --from=dse-server-prep $DSE_HOME $DSE_HOME
-COPY --chown=dse:dse --from=dse-server-prep $DSE_AGENT_HOME $DSE_AGENT_HOME
+COPY --chown=dse:root --from=dse-server-prep $DSE_HOME $DSE_HOME
+COPY --chown=dse:root --from=dse-server-prep $DSE_AGENT_HOME $DSE_AGENT_HOME
 
 # Create folders
 RUN (for dir in /var/lib/cassandra \
@@ -159,21 +161,21 @@ RUN (for dir in /var/lib/cassandra \
                 /var/log/cassandra \
                 /var/log/spark \
                 /config ; do \
-        mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
+        mkdir -p $dir && chown -R dse:root $dir && chmod 775 $dir ; \
     done )
 
 # Use OSS Management API
 RUN rm -rf $DSE_HOME/resources/management-api
-COPY --chown=dse:dse --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
+COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 
 # Add CDC Agent
-COPY --chown=dse:dse --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
+COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME
 WORKDIR $HOME
 
-USER dse
+USER dse:root
 
 # Expose DSE folders
 VOLUME ["/var/lib/cassandra", "/var/lib/spark", "/var/lib/dsefs", "/var/log/cassandra", "/var/log/spark"]

--- a/dse-68/Dockerfile.jdk8
+++ b/dse-68/Dockerfile.jdk8
@@ -15,7 +15,7 @@ ARG URL_PREFIX=https://downloads.datastax.com/enterprise
 ARG TARBALL=dse-${DSE_VERSION}-bin.tar.gz
 ARG DOWNLOAD_URL=${URL_PREFIX}/${TARBALL}
 
-ARG DSE_AGENT_VERSION=6.8.24
+ARG DSE_AGENT_VERSION=6.8.26
 ARG DSE_AGENT_TARBALL=datastax-agent-${DSE_AGENT_VERSION}.tar.gz
 ARG DSE_AGENT_DOWNLOAD_URL=${URL_PREFIX}/${DSE_AGENT_TARBALL}
 
@@ -109,7 +109,8 @@ RUN mkdir $MAAC_PATH \
     && cd ${MAAC_PATH} \
     && ln -s datastax-mgmtapi-agent-dse-6.8-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar \
     && ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar \
-    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar
+    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
 
 #############################################################
 
@@ -122,7 +123,8 @@ ARG CDC_AGENT_EDITION=agent-dse4
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 RUN mkdir ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
-  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar
+  mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
+  chmod -R g+w ${CDC_AGENT_PATH}
 
 FROM datastax/${DS_BASE_DEBIAN}:${BASETAG} AS dse68
 
@@ -149,8 +151,8 @@ RUN set -x \
 
 COPY dse-68/files /
 
-COPY --chown=dse:dse --from=dse-server-prep $DSE_HOME $DSE_HOME
-COPY --chown=dse:dse --from=dse-server-prep $DSE_AGENT_HOME $DSE_AGENT_HOME
+COPY --chown=dse:root --from=dse-server-prep $DSE_HOME $DSE_HOME
+COPY --chown=dse:root --from=dse-server-prep $DSE_AGENT_HOME $DSE_AGENT_HOME
 
 # Create folders
 RUN (for dir in /var/lib/cassandra \
@@ -160,21 +162,21 @@ RUN (for dir in /var/lib/cassandra \
                 /var/log/cassandra \
                 /var/log/spark \
                 /config ; do \
-        mkdir -p $dir && chown -R dse:dse $dir && chmod 777 $dir ; \
+        mkdir -p $dir && chown -R dse:root $dir && chmod 775 $dir ; \
     done )
 
 # Use OSS Management API
 RUN rm -rf $DSE_HOME/resources/management-api
-COPY --chown=dse:dse --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
+COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 
 # Add CDC Agent
-COPY --chown=dse:dse --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
+COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME
 WORKDIR $HOME
 
-USER dse
+USER dse:root
 
 # Expose DSE folders
 VOLUME ["/var/lib/cassandra", "/var/lib/spark", "/var/lib/dsefs", "/var/log/cassandra", "/var/log/spark"]

--- a/dse-68/Dockerfile.jdk8
+++ b/dse-68/Dockerfile.jdk8
@@ -36,7 +36,8 @@ RUN set -x \
 # Use hard links to reduce the size impact of duplicate jars
     && apt-get update \
     && apt-get install -y --install-recommends rdfind \
-    && rdfind -makehardlinks true -makeresultsfile false ${DSE_HOME}
+    && rdfind -makehardlinks true -makeresultsfile false ${DSE_HOME} \
+    && chmod -R g+w ${DSE_HOME} ${DSE_AGENT_HOME}
 
 #############################################################
 
@@ -99,7 +100,7 @@ COPY management-api-agent-4.1.x /tmp/management-api-agent-4.1.x
 COPY management-api-agent-dse-6.8 /tmp/management-api-agent-dse-6.8
 COPY management-api-common /tmp/management-api-common
 COPY management-api-server /tmp/management-api-server
-RUN mkdir $MAAC_PATH \
+RUN mkdir -m 775 $MAAC_PATH \
     && cd /tmp \
     && mvn -q -ff package -DskipTests -P dse \
     && find /tmp -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + \
@@ -121,7 +122,7 @@ ARG CDC_AGENT_VERSION=2.2.9
 ARG CDC_AGENT_EDITION=agent-dse4
 # Download CDC agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
-RUN mkdir ${CDC_AGENT_PATH} && \
+RUN mkdir -m 775 ${CDC_AGENT_PATH} && \
   curl -L -O "https://github.com/datastax/cdc-apache-cassandra/releases/download/v${CDC_AGENT_VERSION}/${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar" && \
   mv ${CDC_AGENT_EDITION}-${CDC_AGENT_VERSION}-all.jar ${CDC_AGENT_PATH}/cdc-agent.jar && \
   chmod -R g+w ${CDC_AGENT_PATH}
@@ -131,7 +132,7 @@ FROM datastax/${DS_BASE_DEBIAN}:${BASETAG} AS dse68
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="dse-server"
 LABEL vendor="DataStax, Inc"
-LABEL release="6.8.26"
+LABEL release="6.8.36"
 
 ENV DSE_HOME /opt/dse
 ENV DSE_AGENT_HOME /opt/agent
@@ -172,11 +173,14 @@ COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
+# Fix COPY directory modes
+RUN chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
+
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME
 WORKDIR $HOME
 
-USER dse:root
+USER dse
 
 # Expose DSE folders
 VOLUME ["/var/lib/cassandra", "/var/lib/spark", "/var/lib/dsefs", "/var/log/cassandra", "/var/log/spark"]

--- a/dse-68/Dockerfile.ubi7
+++ b/dse-68/Dockerfile.ubi7
@@ -12,7 +12,7 @@ FROM registry.access.redhat.com/ubi7/ubi-minimal:${BASETAG} as dse68
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="dse-server"
 LABEL vendor="DataStax, Inc"
-LABEL release="6.8.31"
+LABEL release="6.8.36"
 LABEL summary="The best distribution of Apache Cassandra™ with integrated Search, Analytics, and Graph capabilities"
 LABEL description="Built on the best distribution of Apache Cassandra™, DataStax Enterprise is the always-on database designed to allow you to effortlessly build and scale your apps, integrating graph, search, analytics, administration, developer tooling, and monitoring into a single unified platform. We power your apps' real-time moments so you can create instant insights and powerful customer experiences."
 
@@ -69,7 +69,9 @@ ENV CDC_AGENT_PATH=/opt/cdc_agent
 COPY --chown=dse:root --from=dse-server-base $CDC_AGENT_PATH $CDC_AGENT_PATH
 
 # Adjust directories for ldconfig usage
-RUN chmod g+w /etc /etc/ld.so.cache
+RUN chmod g+w /etc /etc/ld.so.cache  && \
+    # still need to change the mode of the COPY directories, though this does not duplicate layers
+    chmod g+w ${MAAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
 
 # Set user to run as
 USER dse:root

--- a/dse-68/Dockerfile.ubi7
+++ b/dse-68/Dockerfile.ubi7
@@ -17,7 +17,6 @@ LABEL summary="The best distribution of Apache Cassandra™ with integrated Sear
 LABEL description="Built on the best distribution of Apache Cassandra™, DataStax Enterprise is the always-on database designed to allow you to effortlessly build and scale your apps, integrating graph, search, analytics, administration, developer tooling, and monitoring into a single unified platform. We power your apps' real-time moments so you can create instant insights and powerful customer experiences."
 
 ENV DSE_HOME /opt/dse
-ENV DSE_AGENT_HOME /opt/agent
 ENV PATH $DSE_HOME/bin:$PATH
 ENV HOME $DSE_HOME
 
@@ -71,7 +70,7 @@ COPY --chown=dse:root --from=dse-server-base $CDC_AGENT_PATH $CDC_AGENT_PATH
 # Adjust directories for ldconfig usage
 RUN chmod g+w /etc /etc/ld.so.cache  && \
     # still need to change the mode of the COPY directories, though this does not duplicate layers
-    chmod g+w ${MAAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
+    chmod g+w ${MAAC_PATH} ${DSE_HOME} ${CDC_AGENT_PATH}
 
 # Set user to run as
 USER dse:root


### PR DESCRIPTION
This adjusts all images so that the Cassandra/DSE folders are owned by `999:0` (cassandra:root for OSS images, dse:root for DSE images) and that they are run with that same user (i.e. `USER cassandra:root` or `USER dse:root`).

All of the images touched in this PR were missing some part of this setup.

Fixes #311 