### PR TITLE
Upgrade DSE UBI images to 8 for ARM64 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,7 +297,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: datastax/dse-mgmtapi-6_8
-          tags: type=sha,prefix=dse68-ubi7-
+          tags: type=sha,prefix=dse68-ubi8-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -310,11 +310,11 @@ jobs:
       - name: Set outputs
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Build and push DSE 6.8-ubi7
+      - name: Build and push DSE 6.8-ubi8
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          file: dse-68/Dockerfile.ubi7
+          file: dse-68/Dockerfile.ubi8
           build-args: VERSION=dse68-jdk8-${{ steps.vars.outputs.sha_short }}
           context: .
           push: true

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -104,7 +104,7 @@ jobs:
 #        id: docker_dse_ubi_build
 #        uses: docker/build-push-action@v3
 #        with:
-#          file: dse-68/Dockerfile.ubi7
+#          file: dse-68/Dockerfile.ubi8
 #          build-args: VERSION=dse68-jdk8-${{ steps.vars.outputs.sha_short }}
 #          context: .
 #          push: false

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dse-version: [6.8.25, 6.8.26, 6.8.28, 6.8.29, 6.8.30, 6.8.31, 6.8.32, 6.8.33, 6.8.34, 6.8.35, 6.8.36]
+        dse-version: [6.8.25, 6.8.26, 6.8.28, 6.8.29, 6.8.30, 6.8.31, 6.8.32, 6.8.33, 6.8.34, 6.8.35, 6.8.36, 6.8.37]
         image-base: [jdk8, jdk11]
         include:
-          - dse-version: 6.8.36
+          - dse-version: 6.8.37
             latest: true
     runs-on: ubuntu-latest
     steps:
@@ -101,15 +101,15 @@ jobs:
             --target dse68 \
             --platform linux/amd64,linux/arm64 .
 
-  build-dse-68-ubi7:
+  build-dse-68-ubi8:
     needs: build-dse-68-ubuntu
     strategy:
       fail-fast: false
       matrix:
-        dse-version: [6.8.25, 6.8.26, 6.8.28, 6.8.29, 6.8.30, 6.8.31, 6.8.32, 6.8.33, 6.8.34, 6.8.35, 6.8.36]
-        image-base: [ubi7]
+        dse-version: [6.8.25, 6.8.26, 6.8.28, 6.8.29, 6.8.30, 6.8.31, 6.8.32, 6.8.33, 6.8.34, 6.8.35, 6.8.36, 6.8.37]
+        image-base: [ubi8]
         include:
-          - dse-version: 6.8.36
+          - dse-version: 6.8.37
             latest: true
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -97,17 +97,18 @@ Cassandra trunk (currently, these are nightly builds)
 
 DSE 6.8.x
 
-      datastax/dse-mgmtapi-6_8:6.8.25 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.26 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.28 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.29 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.30 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.31 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.32 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.33 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.34 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.35 (jdk8, jdk11 and ubi7 based images)
-      datastax/dse-mgmtapi-6_8:6.8.36 (jdk8, jdk11 and ubi7 based images)
+      datastax/dse-mgmtapi-6_8:6.8.25 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.26 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.28 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.29 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.30 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.31 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.32 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.33 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.34 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.35 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.36 (jdk8, jdk11 and ubi8 based images)
+      datastax/dse-mgmtapi-6_8:6.8.37 (jdk8, jdk11 and ubi8 based images)
 
 ### Cassandra trunk
 

--- a/dse-68/Dockerfile.jdk11
+++ b/dse-68/Dockerfile.jdk11
@@ -10,7 +10,7 @@ ENV DSE_HOME /opt/dse
 ENV DSE_AGENT_HOME /opt/agent
 
 # Get commandline parameters
-ARG DSE_VERSION=6.8.36
+ARG DSE_VERSION=6.8.37
 ARG URL_PREFIX=https://downloads.datastax.com/enterprise
 ARG TARBALL=dse-${DSE_VERSION}-bin.tar.gz
 ARG DOWNLOAD_URL=${URL_PREFIX}/${TARBALL}

--- a/dse-68/Dockerfile.jdk8
+++ b/dse-68/Dockerfile.jdk8
@@ -10,7 +10,7 @@ ENV DSE_HOME /opt/dse
 ENV DSE_AGENT_HOME /opt/agent
 
 # Get commandline parameters
-ARG DSE_VERSION=6.8.36
+ARG DSE_VERSION=6.8.37
 ARG URL_PREFIX=https://downloads.datastax.com/enterprise
 ARG TARBALL=dse-${DSE_VERSION}-bin.tar.gz
 ARG DOWNLOAD_URL=${URL_PREFIX}/${TARBALL}

--- a/dse-68/Dockerfile.ubi8
+++ b/dse-68/Dockerfile.ubi8
@@ -1,13 +1,13 @@
 
-ARG VERSION=6.8.36
-ARG BASETAG=7.8
+ARG VERSION=6.8.37
+ARG BASETAG=8.8
 
 FROM datastax/dse-mgmtapi-6_8:${VERSION} AS dse-server-base
 
 #############################################################
 
-# Based on ubi7 for Python 2 support, when moving to Python 3 use ubi8
-FROM registry.access.redhat.com/ubi7/ubi-minimal:${BASETAG} as dse68
+# Using UBI8 with Python 2 support, eventually we may switch to Python 3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:${BASETAG} as dse68
 
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="dse-server"
@@ -24,7 +24,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install runtime dependencies and updates
 RUN microdnf update && rm -rf /var/cache/yum && \
-    microdnf install --nodocs -y java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel python zlib libaio which findutils hostname && microdnf clean all
+    microdnf install --nodocs -y java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel python2 zlib libaio which findutils hostname iproute shadow-utils procps util-linux glibc-langpack-en && microdnf clean all
 
 WORKDIR $HOME
 

--- a/management-api-agent-dse-6.8/pom.xml
+++ b/management-api-agent-dse-6.8/pom.xml
@@ -29,7 +29,7 @@
     </repository>
   </repositories>
   <properties>
-    <dse.version>6.8.36</dse.version>
+    <dse.version>6.8.37</dse.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This updates the UBI base image for DSE 6.8 images from 7.8 to 8.8 to get ARM64 image support. Also....
Fixes #314