### PR TITLE
Update Artifactory publish repo to public area

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -68,7 +68,7 @@ jobs:
           -DaltSnapshotDeploymentRepository="${REPO}"
 #      - name: Deploy Artifacts to Datsatx Artifactory
 #        run: |
-#          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-releases-local"
+#          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-public-releases-local"
 #          mvn -B clean deploy \
 #          -P dse,dse7 \
 #          -Drevision="${{ env.RELEASE_VERSION }}" \
@@ -86,7 +86,7 @@ jobs:
 #          -DaltSnapshotDeploymentRepository="${REPO}"
       - name: Deploy OpenAPI client to Datastax Artifactory
         run: |
-          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-releases-local"
+          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-public-releases-local"
           mvn -B clean deploy \
           -f management-api-server/target/generated-sources/openapi/java-client/pom.xml \
           -Drevision="${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/openapi-publish.yaml
+++ b/.github/workflows/openapi-publish.yaml
@@ -39,7 +39,7 @@ jobs:
           EOF
       - name: Compile and deploy OpenAPI client
         run: |
-          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-releases-local"
+          REPO="artifactory-releases::default::https://repo.datastax.com/artifactory/datastax-public-releases-local"
           mvn -B clean deploy \
           -f management-api-server/target/generated-sources/openapi/java-client/pom.xml \
           -Drevision="0.1.0-${{ env.COMMITSHA }}" \


### PR DESCRIPTION
Fixes #328

This fixes the location that the OpenAPI client artifacts are published to, as the original one is not public.