### PR TITLE
Add new metric: org.apache.cassandra.metrics.readiness

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -778,4 +778,12 @@ public class NodeOpsProvider {
 
     return submitJob("move", moveOperation, async);
   }
+
+  @Rpc(name = "readiness")
+  public boolean ready() throws IOException {
+    logger.debug("Checking if Cassandra has readiness");
+    String query = QueryBuilder.selectFrom("system", "local").column("cluster_name").asCql();
+    UntypedResultSet rows = ShimLoader.instance.get().processQuery(query, ConsistencyLevel.ONE);
+    return rows != null && rows.size() > 0;
+  }
 }

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
@@ -49,7 +49,7 @@ public class CassandraMetricDefinition
     this.filler = samples -> samples.add(buildSample());
   }
 
-  void setFiller(Consumer<List<Collector.MetricFamilySamples.Sample>> filler) {
+  public void setFiller(Consumer<List<Collector.MetricFamilySamples.Sample>> filler) {
     this.filler = filler;
   }
 

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
@@ -75,8 +75,7 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
   private Method decayingHistogramOffsetMethod = null;
 
   public CassandraMetricRegistryListener(
-      ConcurrentHashMap<String, RefreshableMetricFamilySamples> familyCache, Configuration config)
-      throws NoSuchMethodException {
+      ConcurrentHashMap<String, RefreshableMetricFamilySamples> familyCache, Configuration config) {
     parser =
         new CassandraMetricNameParser(
             CassandraMetricsTools.DEFAULT_LABEL_NAMES,


### PR DESCRIPTION
This could replace the /readiness call itself also (to sync them). 

Fixes https://github.com/riptano/mission-control/issues/552