### PR TITLE
Fix DSE UBI Dockerfile so tests don't fail for new functionality

### DIFF
--- a/dse-68/Dockerfile.ubi8
+++ b/dse-68/Dockerfile.ubi8
@@ -4,6 +4,46 @@ ARG UBI_BASETAG=latest
 
 FROM datastax/dse-mgmtapi-6_8:${DSE_VERSION} AS dse-server-base
 
+FROM --platform=$BUILDPLATFORM maven:3.8.7-eclipse-temurin-11 as mgmtapi-setup
+
+WORKDIR /
+
+ENV MAAC_PATH /opt/management-api
+ENV DSE_HOME /opt/dse
+
+COPY pom.xml /tmp/pom.xml
+COPY management-api-agent-common/pom.xml /tmp/management-api-agent-common/pom.xml
+COPY management-api-agent-3.x/pom.xml /tmp/management-api-agent-3.x/pom.xml
+COPY management-api-agent-4.x/pom.xml /tmp/management-api-agent-4.x/pom.xml
+COPY management-api-agent-4.1.x/pom.xml /tmp/management-api-agent-4.1.x/pom.xml
+COPY management-api-agent-dse-6.8/pom.xml tmp/management-api-agent-dse-6.8/pom.xml
+COPY management-api-common/pom.xml /tmp/management-api-common/pom.xml
+COPY management-api-server/pom.xml /tmp/management-api-server/pom.xml
+COPY settings.xml settings.xml /root/.m2/
+# this duplicates work done in the next steps, but this should provide
+# a solid cache layer that only gets reset on pom.xml changes
+RUN cd /tmp && mvn -q -ff -T 1C install -DskipOpenApi -P dse && rm -rf target
+
+COPY management-api-agent-common /tmp/management-api-agent-common
+COPY management-api-agent-3.x /tmp/management-api-agent-3.x
+COPY management-api-agent-4.x /tmp/management-api-agent-4.x
+COPY management-api-agent-4.1.x /tmp/management-api-agent-4.1.x
+COPY management-api-agent-dse-6.8 /tmp/management-api-agent-dse-6.8
+COPY management-api-common /tmp/management-api-common
+COPY management-api-server /tmp/management-api-server
+RUN mkdir -m 775 $MAAC_PATH \
+    && cd /tmp \
+    && mvn -q -ff package -DskipTests  -DskipOpenApi -P dse \
+    && find /tmp -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' + \
+    && rm $MAAC_PATH/datastax-mgmtapi-agent-3* \
+    && rm $MAAC_PATH/datastax-mgmtapi-agent-4* \
+    && rm $MAAC_PATH/datastax-mgmtapi-*common* \
+    && cd ${MAAC_PATH} \
+    && ln -s datastax-mgmtapi-agent-dse-6.8-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar \
+    && ln -s datastax-mgmtapi-agent-0.1.0-SNAPSHOT.jar datastax-mgmtapi-agent.jar \
+    && ln -s datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar datastax-mgmtapi-server.jar && \
+    chmod -R g+w ${MAAC_PATH}
+
 #############################################################
 
 # Using UBI8 with Python 2 support, eventually we may switch to Python 3
@@ -64,7 +104,7 @@ RUN chmod 0555 /entrypoint.sh /overwritable-conf-files /licenses /base-checks.sh
 # Use OSS Management API
 ENV CASSANDRA_CONF ${DSE_HOME}/resources/cassandra/conf
 ENV MAAC_PATH /opt/management-api
-COPY --chown=dse:root --from=dse-server-base $MAAC_PATH $MAAC_PATH
+COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
 COPY --chown=dse:root --from=dse-server-base $CDC_AGENT_PATH $CDC_AGENT_PATH


### PR DESCRIPTION
I should create a ticket.....

This fixes the issue of tests failing against DSE UBI images by building the Management API bits from the branch the tests are running, as opposed to copying them from the most recently published DSE Ubuntu image (that may not have the current branch's functionality being tested)

**Fixes issue**
https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/357