### PR TITLE
 Replace use of BigIntegers in Resources' model classes with Longs

### DIFF
--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -2147,10 +2147,12 @@
         "type" : "object",
         "properties" : {
           "end" : {
-            "type" : "integer"
+            "type" : "integer",
+            "format" : "int64"
           },
           "start" : {
-            "type" : "integer"
+            "type" : "integer",
+            "format" : "int64"
           }
         },
         "required" : [ "end", "start" ]

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v2/models/RingRange.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v2/models/RingRange.java
@@ -7,7 +7,6 @@
 package com.datastax.mgmtapi.resources.v2.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.math.BigInteger;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -16,28 +15,28 @@ public final class RingRange {
       (RingRange o1, RingRange o2) -> o1.start.compareTo(o2.start);
 
   @JsonProperty(value = "start", required = true)
-  public final BigInteger start;
+  public final Long start;
 
   @JsonProperty(value = "end", required = true)
-  public final BigInteger end;
+  public final Long end;
 
   public RingRange(
-      @JsonProperty(value = "start", required = true) BigInteger start,
-      @JsonProperty(value = "end", required = true) BigInteger end) {
+      @JsonProperty(value = "start", required = true) Long start,
+      @JsonProperty(value = "end", required = true) Long end) {
     this.start = start;
     this.end = end;
   }
 
   public RingRange(String... range) {
-    start = new BigInteger(range[0]);
-    end = new BigInteger(range[1]);
+    start = Long.valueOf(range[0]);
+    end = Long.valueOf(range[1]);
   }
 
-  public BigInteger getStart() {
+  public Long getStart() {
     return start;
   }
 
-  public BigInteger getEnd() {
+  public Long getEnd() {
     return end;
   }
 


### PR DESCRIPTION
Replace usage of BigIntegers with Longs. Hopefully this will fix the issues with BigIntegers being represented in open API spec as ints.