### PR TITLE
Add hot reloading of SslContext

### DIFF
--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -513,6 +513,7 @@ public class Cli implements Runnable {
                 break;
               }
               if (reloadNeeded) {
+                logger.info("Detected change in the SSL/TLS certificates, reloading.");
                 createSSLContext();
               }
             } catch (InterruptedException e) {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -452,7 +452,8 @@ public class Cli implements Runnable {
     checkUnixSocket();
   }
 
-  private void createSSLContext() throws SSLException {
+  @VisibleForTesting
+  void createSSLContext() throws SSLException {
     this.sslContext =
         SslContextBuilder.forServer(tlsCert, tlsKey)
             .trustManager(tlsCaCert)
@@ -461,7 +462,8 @@ public class Cli implements Runnable {
             .build();
   }
 
-  private void createSSLWatcher() throws IOException {
+  @VisibleForTesting
+  void createSSLWatcher() throws IOException {
     // Watch for tls_cert_file, tls_key_file and tls_ca_cert_file, add all their directories to
     // Filesystem Watcher
     WatchService watchService = FileSystems.getDefault().newWatchService();

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NettyTlsClientAuthTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NettyTlsClientAuthTest.java
@@ -437,8 +437,8 @@ public class NettyTlsClientAuthTest {
             keyCopy.toFile().getAbsolutePath());
     cli.preflightChecks();
     Cli spy = Mockito.spy(cli);
-    cli.createSSLContext();
-    cli.createSSLWatcher();
+    spy.createSSLContext();
+    spy.createSSLWatcher();
 
     verify(spy, times(1)).createSSLContext();
     verify(spy, times(1)).createSSLWatcher();

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NettyTlsClientAuthTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NettyTlsClientAuthTest.java
@@ -9,6 +9,8 @@ import static org.jboss.resteasy.test.TestPortProvider.generateURL;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.datastax.mgmtapi.helpers.IntegrationTestUtils;
 import com.datastax.mgmtapi.helpers.NettyHttpClient;
@@ -41,6 +43,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -56,6 +60,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 public class NettyTlsClientAuthTest {
   static String BASE_URI = generateURL("");
@@ -390,5 +395,57 @@ public class NettyTlsClientAuthTest {
       FileUtils.deleteQuietly(new File(cassSock));
       FileUtils.deleteQuietly(new File(mgmtSock));
     }
+  }
+
+  @Test
+  public void testHotReload() throws Exception {
+    assumeTrue(IntegrationTestUtils.shouldRun());
+
+    String mgmtSock = SocketUtils.makeValidUnixSocketFile(null, "management-netty-tls-mgmt");
+    new File(mgmtSock).deleteOnExit();
+    String cassSock = SocketUtils.makeValidUnixSocketFile(null, "management-netty-tls-cass");
+    new File(cassSock).deleteOnExit();
+
+    Path tempDirectory = Files.createTempDirectory("reload-test");
+
+    List<String> extraArgs =
+        IntegrationTestUtils.getExtraArgs(
+            NettyTlsClientAuthTest.class, "", temporaryFolder.getRoot());
+
+    File trustCertFile =
+        IntegrationTestUtils.getFile(getClass(), "mutual_auth_client_cert_chain.pem");
+    File serverKeyFile = IntegrationTestUtils.getFile(getClass(), "mutual_auth_server.key");
+    File serverCrtFile = IntegrationTestUtils.getFile(getClass(), "mutual_auth_server.crt");
+
+    // Copy TLS files to temp directory
+    Path trustCertCopy =
+        Files.copy(trustCertFile.toPath(), tempDirectory.resolve(trustCertFile.toPath()));
+    Path keyCopy =
+        Files.copy(serverKeyFile.toPath(), tempDirectory.resolve(serverKeyFile.toPath()));
+    Path crtCopy =
+        Files.copy(serverCrtFile.toPath(), tempDirectory.resolve(serverCrtFile.toPath()));
+
+    Cli cli =
+        new Cli(
+            Lists.newArrayList("file://" + mgmtSock, BASE_URI),
+            IntegrationTestUtils.getCassandraHome(),
+            cassSock,
+            false,
+            extraArgs,
+            trustCertCopy.toFile().getAbsolutePath(),
+            crtCopy.toFile().getAbsolutePath(),
+            keyCopy.toFile().getAbsolutePath());
+    cli.preflightChecks();
+    Cli spy = Mockito.spy(cli);
+    cli.createSSLContext();
+    cli.createSSLWatcher();
+
+    verify(spy, times(1)).createSSLContext();
+    verify(spy, times(1)).createSSLWatcher();
+
+    // Modify files..
+    Files.copy(trustCertFile.toPath(), tempDirectory.resolve(trustCertFile.toPath()));
+
+    verify(spy, Mockito.timeout(1000)).createSSLContext();
   }
 }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpClient.java
@@ -7,7 +7,6 @@ package com.datastax.mgmtapi.helpers;
 
 import static org.junit.Assert.fail;
 
-import com.datastax.mgmtapi.Cli;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -59,7 +58,6 @@ public class NettyHttpClient {
               .trustManager(clientCaFile)
               .keyManager(clientCertFile, clientKeyFile, null)
               .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-              .protocols(Cli.PROTOCOL_TLS_V1_2)
               .sessionCacheSize(0)
               .sessionTimeout(0)
               .build();

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpIPCClient.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpIPCClient.java
@@ -7,7 +7,6 @@ package com.datastax.mgmtapi.helpers;
 
 import static org.junit.Assert.fail;
 
-import com.datastax.mgmtapi.Cli;
 import com.datastax.mgmtapi.ipc.IPCController;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.channel.Channel;
@@ -63,7 +62,6 @@ public class NettyHttpIPCClient {
           SslContextBuilder.forClient()
               .trustManager(clientCaFile)
               .keyManager(clientCertFile, clientKeyFile, null)
-              .protocols(Cli.PROTOCOL_TLS_V1_2)
               .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
               .sessionCacheSize(0)
               .sessionTimeout(0)


### PR DESCRIPTION
 Create a Filewatcher to detect any changes in the filesystem related to these TLS files (key, CA, cert). If something happens on the disk to these files, simply reload the SslContext.

Also, change v1.2 restriction to Netty defaults (including support for TLS v1.3)

Fixes #375 