### PR TITLE
Test PR to see if removing enum from lists helps serialise Job type

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/util/JobDto.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/util/JobDto.java
@@ -10,16 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.cassandra.utils.progress.ProgressEventType;
 
-public class Job {
-  public enum JobStatus {
-    ERROR,
-    COMPLETED,
-    WAITING;
-  }
+public class JobDto {
 
   public String jobId;
   public String jobType;
-  public JobStatus status;
+  public String status;
   public long submitTime;
   public long startTime;
   public long finishedTime;
@@ -52,11 +47,11 @@ public class Job {
 
   public List<StatusChange> statusChanges;
 
-  public Job(String jobType, String jobId) {
+  public JobDto(String jobType, String jobId) {
     this.jobType = jobType;
     this.jobId = jobId;
     submitTime = System.currentTimeMillis();
-    status = JobStatus.WAITING;
+    status = "WAITING";
     statusChanges = new ArrayList<>();
   }
 
@@ -74,11 +69,11 @@ public class Job {
     return jobType;
   }
 
-  public JobStatus getStatus() {
+  public String getStatus() {
     return status;
   }
 
-  public void setStatus(JobStatus status) {
+  public void setStatus(String status) {
     this.status = status;
   }
 

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -44,6 +44,7 @@ public abstract class BaseDockerIntegrationTest {
   protected static final String BASE_PATH = "http://localhost:8080/api/v0";
   protected static final String BASE_PATH_V1 = "http://localhost:8080/api/v1";
   protected static final String BASE_PATH_V2 = "http://localhost:8080/api/v2";
+  protected static final String BASE_HOST = "http://localhost:8080";
   protected static final URL BASE_URL;
   protected static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NonDestructiveOpsIT.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
-import com.datastax.mgmtapi.client.api.DefaultApi;
-import com.datastax.mgmtapi.client.invoker.ApiClient;
 import com.datastax.mgmtapi.helpers.IntegrationTestUtils;
 import com.datastax.mgmtapi.helpers.NettyHttpClient;
 import com.datastax.mgmtapi.resources.models.CompactRequest;
@@ -34,6 +32,8 @@ import com.datastax.mgmtapi.resources.models.ReplicationSetting;
 import com.datastax.mgmtapi.resources.models.ScrubRequest;
 import com.datastax.mgmtapi.resources.models.Table;
 import com.datastax.mgmtapi.resources.models.TakeSnapshotRequest;
+import com.datastax.mgmtapi.resources.v2.models.RepairParallelism;
+import com.datastax.mgmtapi.resources.v2.models.RepairRequestResponse;
 import com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -1036,38 +1036,61 @@ public class NonDestructiveOpsIT extends BaseDockerIntegrationTest {
             });
   }
 
-  public void ensureStatusChanges() throws Exception {
+  @Test
+  public void testEnsureStatusChanges() throws Exception {
     assumeTrue(IntegrationTestUtils.shouldRun());
     ensureStarted();
     NettyHttpClient client = new NettyHttpClient(BASE_URL);
-    DefaultApi apiClient = new DefaultApi(new ApiClient().setBasePath(BASE_HOST));
-    com.datastax.mgmtapi.client.model.RepairRequest req =
-        new com.datastax.mgmtapi.client.model.RepairRequest()
-            .keyspace("system_distributed")
-            .fullRepair(true)
-            .notifications(true)
-            .repairParallelism(
-                com.datastax.mgmtapi.client.model.RepairRequest.RepairParallelismEnum.SEQUENTIAL)
-            .associatedTokens(
-                Collections.singletonList(
-                    new com.datastax.mgmtapi.client.model.RingRange()
-                        .start(Long.valueOf(-1))
-                        .end(Long.valueOf(100))));
+
+    com.datastax.mgmtapi.resources.v2.models.RepairRequest req =
+        new com.datastax.mgmtapi.resources.v2.models.RepairRequest(
+            "system_distributed",
+            null,
+            true,
+            true,
+            Collections.singletonList(
+                new com.datastax.mgmtapi.resources.v2.models.RingRange(-1L, 100L)),
+            RepairParallelism.SEQUENTIAL,
+            null,
+            null);
+
     logger.info("Sending repair request: {}", req);
-    String jobID = apiClient.putRepairV2(req).getRepairId();
-    Integer repairID = Integer.parseInt(jobID.substring(7)); // Trimming off "repair-" prefix.
+    URI repairUri = new URIBuilder(BASE_PATH_V2 + "repairs").build();
+    Pair<Integer, String> repairResp =
+        client
+            .put(repairUri.toURL(), new ObjectMapper().writeValueAsString(req))
+            .thenApply(this::responseAsCodeAndBody)
+            .join();
+    String jobID =
+        new ObjectMapper().readValue(repairResp.getRight(), RepairRequestResponse.class).repairID;
+    Integer repairID =
+        Integer.parseInt(
+            jobID.substring(7) // Trimming off "repair-" prefix.
+            );
     logger.info("Repair ID: {}", repairID);
     assertThat(repairID).isNotNull();
     assertThat(repairID).isGreaterThan(0);
 
-    com.datastax.mgmtapi.client.model.Job status = apiClient.getJobStatus(jobID);
-    logger.info("Repair job status: {}", status);
-    assertThat(status.getStatus()).isNotNull();
-    assertThat(status.getStatusChanges()).isNotNull();
-    await().atMost(5, SECONDS).until(() -> status.getStatusChanges().size() > 0);
+    URI statusUri =
+        new URIBuilder(BASE_PATH_V2 + "/ops/executor/job").addParameter("job_id", jobID).build();
+    Pair<Integer, String> statusResp =
+        client.get(statusUri.toURL()).thenApply(this::responseAsCodeAndBody).join();
+    logger.info("Repair job status: {}", statusResp);
+    Job jobStatus = new ObjectMapper().readValue(statusResp.getRight(), Job.class);
+
+    assertThat(jobStatus.getStatus()).isNotNull();
+    assertThat(jobStatus.getStatusChanges()).isNotNull();
     await()
         .atMost(5, SECONDS)
         .until(
-            () -> status.getStatus() == com.datastax.mgmtapi.client.model.Job.StatusEnum.COMPLETED);
+            () -> {
+              Pair<Integer, String> statusResp2 =
+                  client.get(statusUri.toURL()).thenApply(this::responseAsCodeAndBody).join();
+              logger.info("Repair job status: {}", statusResp);
+              Job jobStatus2 = new ObjectMapper().readValue(statusResp.getRight(), Job.class);
+              return jobStatus2.getStatusChanges().size() > 0
+                  && jobStatus2.getStatus()
+                      == com.datastax.mgmtapi.resources.models.Job.JobStatus.COMPLETED;
+            });
   }
 }


### PR DESCRIPTION
This PR is a test to see if the agent will build and run with a Job type returned from `getJobStatus()` which does not contain Lists of types containing enums. 

If it fails the next step will be to remove the `ProgressEventType` enum entirely and replace it with a string in all locations.