### PR TITLE
Scrub is not functioning with keyspaceName "ALL"

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -504,16 +504,16 @@ public class NodeOpsProvider {
           for (String keyspace : keyspaceList) {
             try {
               ShimLoader.instance
-                      .get()
-                      .getStorageService()
-                      .scrub(
-                              disableSnapshot,
-                              skipCorrupted,
-                              checkData,
-                              reinsertOverflowedTTL,
-                              jobs,
-                              keyspace,
-                              tables.toArray(new String[]{}));
+                  .get()
+                  .getStorageService()
+                  .scrub(
+                      disableSnapshot,
+                      skipCorrupted,
+                      checkData,
+                      reinsertOverflowedTTL,
+                      jobs,
+                      keyspace,
+                      tables.toArray(new String[] {}));
             } catch (IOException | ExecutionException | InterruptedException e) {
               logger.error("Failed to execute scrub: ", e);
               throw new RuntimeException(e);


### PR DESCRIPTION
Unlike the REST API suggests (and tests), the keyspaceName "ALL" is not accepted by the NodeOpsProvider. 

Fixes https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/448