### PR TITLE
TableOpsResources should not use compactRequest.tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 
+* [BUGFIX] [#448](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/448) Scrub did not work when targetting all the keyspaces
+* [BUGFIX] [#437](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/437) Compaction threw NPE if used without target TokenRange
+
 ## v0.1.72 (2023-12-19)
 
 * [BUGFIX]  [#434](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/434) Temporarily disable arm64 support for DSE images

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/NodeOpsProvider.java
@@ -94,6 +94,7 @@ public class NodeOpsProvider {
     resultMap.put("submit_time", String.valueOf(jobWithId.getSubmitTime()));
     resultMap.put("end_time", String.valueOf(jobWithId.getFinishedTime()));
     if (jobWithId.getStatus() == Job.JobStatus.ERROR) {
+      logger.error("Task " + jobId + " execution failed", jobWithId.getError());
       resultMap.put("error", jobWithId.getError().getLocalizedMessage());
     }
 

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/TableOpsResources.java
@@ -217,7 +217,7 @@ public class TableOpsResources extends BaseResources {
                 "CALL NodeOps.forceKeyspaceCompaction(?, ?, ?, ?)",
                 compactRequest.splitOutput,
                 keyspaceName,
-                compactRequest.tables,
+                tables,
                 false);
           }
 

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/TableOpsResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/v1/TableOpsResources.java
@@ -237,7 +237,7 @@ public class TableOpsResources extends BaseResources {
                       "CALL NodeOps.forceKeyspaceCompaction(?, ?, ?, ?)",
                       compactRequest.splitOutput,
                       keyspaceName,
-                      compactRequest.tables,
+                      tables,
                       true))
               .build();
         });


### PR DESCRIPTION
We already had a "tables" variable, which was empty ArrayList in case the compactRequest.tables was null. This just wasn't used if tokenRange wasn't set.

Also, add logging in case we get Throwable so it makes debugging easier.

Fixes #437 

Tested manually:

```
➜  cass-operator git:(master) ✗ kubectl get cassandratask                                     
NAME              DATACENTER   JOB       SCHEDULED   STARTED   COMPLETED
example-compact   dc2          compact               41s       31s
➜  cass-operator git:(master) ✗
```