### PR TITLE
Fix the SSLContext to point to the right context 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 
+* [BUGFIX] [#507]((https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/507) Fix the SSLContext reloading in the initChannel when certificates have changed.
+
 ## v0.1.82 (2024-06-14)
-* [FEATURE] [#504] (https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/504) Add DSE 6.9.0-rc.1 to the build matrix
+* [FEATURE] [#504](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/504) Add DSE 6.9.0-rc.1 to the build matrix
 
 ## v0.1.81 (2024-06-13)
 * [FEATURE] [#497](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/497) Add DSE 6.8.49 to the build matrix

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/http/NettyMetricsServerTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/http/NettyMetricsServerTest.java
@@ -1,2 +1,0 @@
-package io.k8ssandra.metrics.http;public class NettyMetricsServerTest {
-}

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/http/NettyMetricsServerTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/http/NettyMetricsServerTest.java
@@ -1,0 +1,2 @@
+package io.k8ssandra.metrics.http;public class NettyMetricsServerTest {
+}

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -540,6 +540,11 @@ public class Cli implements Runnable {
               if (reloadNeeded) {
                 logger.info("Detected change in the SSL/TLS certificates, reloading.");
                 createSSLContext();
+                for (NettyJaxrsServer server : servers) {
+                  if (server instanceof NettyJaxrsTLSServer) {
+                    ((NettyJaxrsTLSServer) server).setSslContext(this.sslContext);
+                  }
+                }
               }
             } catch (InterruptedException e) {
               // Do something.. just log?

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/NettyJaxrsTLSServer.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/NettyJaxrsTLSServer.java
@@ -28,7 +28,7 @@ import org.jboss.resteasy.plugins.server.netty.RestEasyHttpResponseEncoder;
 import org.jboss.resteasy.util.EmbeddedServerHelper;
 
 public class NettyJaxrsTLSServer extends NettyJaxrsServer {
-  private final SslContext sslContext;
+  private SslContext sslContext;
   private final EventLoopGroup eventLoopGroup = new NioEventLoopGroup(2);
   private final Map<ChannelOption, Object> channelOptions = Collections.emptyMap();
   private final int maxRequestSize = 1024 * 1024 * 10;
@@ -102,6 +102,10 @@ public class NettyJaxrsTLSServer extends NettyJaxrsServer {
     }
 
     channelPipeline.addLast(new RequestHandler(dispatcher));
+  }
+
+  public void setSslContext(SslContext sslContext) {
+    this.sslContext = sslContext;
   }
 
   @Override


### PR DESCRIPTION
SSLContext should be refreshed to point to the right context, Instead of the old one when hot reloading SSL.

Fixes #507 