### PR TITLE
Change relabeling rules for processing internode (inbound / outbound)…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 * [BUGFIX] [#510](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/510) CDC is not working in the OSS images (at least not UBI)
 * [BUGFIX] [#507](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/507) Fix the SSLContext reloading in the initChannel when certificates have changed.
 * [FEATURE] [#511](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/511) Add DSE 6.8.50 and DSE 6.9.0-rc.3 to the build matrix
+* [BUGFIX] [#512](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/512) Add relabeling rules for internode connection metrics (inbound and outbound)
 
 ## v0.1.82 (2024-06-14)
 * [FEATURE] [#504](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/504) Add DSE 6.9.0-rc.1 to the build matrix

--- a/management-api-agent-common/src/main/resources/default-metric-settings.yaml
+++ b/management-api-agent-common/src/main/resources/default-metric-settings.yaml
@@ -117,6 +117,27 @@ relabels:
   # SSTable Index metrics
   # BufferPool metrics
   # Client metrics
+  # Internode metrics
+  - regex: "org\\.apache\\.cassandra\\.metrics\\.Connection\\.(\\w+)\\.(.+)$"
+    replacement: org_apache_cassandra_metrics_connection_$1
+    sourceLabels:
+      - __origname__
+    targetLabel: __name__
+  - regex: "org\\.apache\\.cassandra\\.metrics\\.Connection\\.(\\w+)\\.(.+)$"
+    replacement: $2
+    sourceLabels:
+      - __origname__
+    targetLabel: peer_ip
+  - regex: "org\\.apache\\.cassandra\\.metrics\\.InboundConnection\\.(\\w+)\\.(.+)$"
+    replacement: org_apache_cassandra_metrics_inbound_connection_$1
+    sourceLabels:
+      - __origname__
+    targetLabel: __name__
+  - regex: "org\\.apache\\.cassandra\\.metrics\\.InboundConnection\\.(\\w+)\\.(.+)$"
+    replacement: $2
+    sourceLabels:
+      - __origname__
+    targetLabel: peer_ip
   # Batch metrics
   # JVM metrics
   - regex: "jvm\\.buffers\\.(\\w+)\\.(\\w+)"

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/config/ConfigReaderTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/config/ConfigReaderTest.java
@@ -72,8 +72,8 @@ public class ConfigReaderTest {
 
     System.setProperty(ConfigReader.CONFIG_PATH_PROPERTY, resource.getFile());
     Configuration configuration = ConfigReader.readConfig();
-    assertEquals(30, configuration.getRelabels().size());
-    assertEquals("(.*);(b.*)", configuration.getRelabels().get(28).getRegexp().toString());
-    assertEquals("^(a|b|c),.*", configuration.getRelabels().get(29).getRegexp().toString());
+    assertEquals(34, configuration.getRelabels().size());
+    assertEquals("(.*);(b.*)", configuration.getRelabels().get(32).getRegexp().toString());
+    assertEquals("^(a|b|c),.*", configuration.getRelabels().get(33).getRegexp().toString());
   }
 }


### PR DESCRIPTION
… metrics

Results in the following format:

```
org_apache_cassandra_metrics_connection_large_message_dropped_bytes_due_to_timeout{host="df4529f6-2bc0-4c91-90b6-bcb9a90cbfba",instance="10.244.3.4",cluster="cluster2",datacenter="dc2",rack="r1",pod_name="cluster2-dc2-r1-sts-1",node_name="kind-worker2",peer_ip="10.244.4.13_7000",} 0.0
```

And

```
org_apache_cassandra_metrics_inbound_connection_expired_count{host="df4529f6-2bc0-4c91-90b6-bcb9a90cbfba",instance="10.244.3.4",cluster="cluster2",datacenter="dc2",rack="r1",pod_name="cluster2-dc2-r1-sts-1",node_name="kind-worker2",peer_ip="10.244.4.13_7000",} 0.0
```

Thus parsing the peer_ip to a label. 

Fixes #512