### PR TITLE
Make DSE 6.8 able to run on readOnlyRootFilesystem

### DIFF
--- a/dse/Dockerfile-dse6.8.jdk11
+++ b/dse/Dockerfile-dse6.8.jdk11
@@ -149,6 +149,7 @@ ENV DSE_AGENT_HOME=/opt/agent
 ENV CASSANDRA_CONF=${DSE_HOME}/resources/cassandra/conf
 ENV MAAC_PATH=/opt/management-api
 ENV CDC_AGENT_PATH=/opt/cdc_agent
+ENV MGMT_AGENT_JAR="${MAAC_PATH}/datastax-mgmtapi-agent.jar"
 
 RUN set -eux; \
     apt-get update; \
@@ -185,6 +186,11 @@ COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
+# Add management-api
+RUN if ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" < ${CASSANDRA_CONF}/cassandra-env.sh ; then \
+      echo "" >> ${CASSANDRA_CONF}/cassandra-env.sh && \
+      echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" >> ${CASSANDRA_CONF}/cassandra-env.sh ; \
+  fi
 # Fix COPY directory modes
 RUN chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
 

--- a/dse/Dockerfile-dse6.8.jdk8
+++ b/dse/Dockerfile-dse6.8.jdk8
@@ -151,6 +151,7 @@ ENV DSE_AGENT_HOME=/opt/agent
 ENV CASSANDRA_CONF=${DSE_HOME}/resources/cassandra/conf
 ENV MAAC_PATH=/opt/management-api
 ENV CDC_AGENT_PATH=/opt/cdc_agent
+ENV MGMT_AGENT_JAR="${MAAC_PATH}/datastax-mgmtapi-agent.jar"
 
 RUN set -eux; \
     apt-get update; \
@@ -187,6 +188,11 @@ COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 COPY --chown=dse:root --from=mgmtapi-setup $CDC_AGENT_PATH $CDC_AGENT_PATH
 
+# Add management-api
+RUN if ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" < ${CASSANDRA_CONF}/cassandra-env.sh ; then \
+      echo "" >> ${CASSANDRA_CONF}/cassandra-env.sh && \
+      echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" >> ${CASSANDRA_CONF}/cassandra-env.sh ; \
+  fi
 # Fix COPY directory modes
 RUN chmod g+w ${MAAC_PATH} ${MCAC_PATH} ${DSE_HOME} ${DSE_AGENT_HOME} ${CDC_AGENT_PATH}
 

--- a/dse/Dockerfile-dse6.8.ubi8
+++ b/dse/Dockerfile-dse6.8.ubi8
@@ -113,6 +113,7 @@ RUN chmod 0555 /entrypoint.sh /overwritable-conf-files /licenses /base-checks.sh
 # Use OSS Management API
 ENV CASSANDRA_CONF=${DSE_HOME}/resources/cassandra/conf
 ENV MAAC_PATH=/opt/management-api
+ENV MGMT_AGENT_JAR="${MAAC_PATH}/datastax-mgmtapi-agent.jar"
 COPY --chown=dse:root --from=mgmtapi-setup $MAAC_PATH $MAAC_PATH
 # Add CDC Agent
 ENV CDC_AGENT_PATH=/opt/cdc_agent
@@ -122,6 +123,12 @@ COPY --chown=dse:root --from=dse-server-base $CDC_AGENT_PATH $CDC_AGENT_PATH
 RUN chmod g+w /etc /etc/ld.so.cache  && \
     # still need to change the mode of the COPY directories, though this does not duplicate layers
     chmod g+w ${MAAC_PATH} ${DSE_HOME} ${CDC_AGENT_PATH}
+
+# Add management-api
+RUN if ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" < ${CASSANDRA_CONF}/cassandra-env.sh ; then \
+      echo "" >> ${CASSANDRA_CONF}/cassandra-env.sh && \
+      echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MGMT_AGENT_JAR}\"" >> ${CASSANDRA_CONF}/cassandra-env.sh ; \
+  fi
 
 # Set user to run as
 USER dse:root

--- a/dse/files/overwritable-conf-files
+++ b/dse/files/overwritable-conf-files
@@ -7,6 +7,7 @@ resources/solr/web
 resources/tomcat/conf
 resources/tomcat/conf/webapps
 resources/cassandra/conf/cassandra-env.sh
+resources/cassandra/conf/jvm-dependent.sh
 resources/hadoop2-client/conf/hadoop-env.sh
 resources/hadoop2-client/conf/httpfs-env.sh
 resources/hadoop2-client/conf/kms-env.sh

--- a/dse/files/overwritable-conf-files
+++ b/dse/files/overwritable-conf-files
@@ -1,7 +1,6 @@
 resources/cassandra/conf/jvm.options
 resources/spark/conf/hive-site.xml
 resources/dse/conf/dse.default
-bin/dse-env.sh
 resources/solr/conf
 resources/solr/web
 resources/tomcat/conf


### PR DESCRIPTION
DSE will not start without this file, so it should be copied from /config.