### PR TITLE
In /liveness, verify that Cassandra is still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [ENHANCEMENT] [#552](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/552) Improve "liveness" probe implementation
 
 ## v0.1.87 (2024-10-02)
 * [FEATURE] [#535](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/535) Add Cassandra 5.0.0 to the build matrix

--- a/cassandra/Dockerfile-3.11.ubi8
+++ b/cassandra/Dockerfile-3.11.ubi8
@@ -101,7 +101,7 @@ RUN if test ! -e apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz; then curl -L 
     chown -R cassandra:root ${CASSANDRA_HOME} && \
     chmod -R a+rwX ${CASSANDRA_HOME}
 
-FROM cassandra-builder-${TARGETARCH} as cassandra-builder
+FROM cassandra-builder-${TARGETARCH} AS cassandra-builder
 
 #############################################################
 # Build the Management API

--- a/cassandra/Dockerfile-4.0.ubi8
+++ b/cassandra/Dockerfile-4.0.ubi8
@@ -101,7 +101,7 @@ RUN if test ! -e apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz; then curl -L 
     chown -R cassandra:root ${CASSANDRA_HOME} && \
     chmod -R a+rwX ${CASSANDRA_HOME}
 
-FROM cassandra-builder-${TARGETARCH} as cassandra-builder
+FROM cassandra-builder-${TARGETARCH} AS cassandra-builder
 
 #############################################################
 # Build the Management API

--- a/cassandra/Dockerfile-4.1.ubi8
+++ b/cassandra/Dockerfile-4.1.ubi8
@@ -102,7 +102,7 @@ RUN if test ! -e apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz; then curl -L 
     chown -R cassandra:root ${CASSANDRA_HOME} && \
     chmod -R a+rwX ${CASSANDRA_HOME}
 
-FROM cassandra-builder-${TARGETARCH} as cassandra-builder
+FROM cassandra-builder-${TARGETARCH} AS cassandra-builder
 
 #############################################################
 # Build the Management API

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -108,7 +108,6 @@ public class LifecycleResources extends BaseResources {
               examples = @ExampleObject(value = "error message")))
   public synchronized Response startNode(
       @QueryParam("profile") String profile, @QueryParam("replace_ip") String replaceIp) {
-    app.setRequestedState(STARTED);
 
     // Todo we should add a CALL getPid command and compare;
     boolean canConnect;
@@ -195,6 +194,8 @@ public class LifecycleResources extends BaseResources {
           // DSE and HCD need the extra "cassandra" startup argument
           dbCmdPb.command().add("cassandra");
         }
+        dbCmdPb.command().add("-p");
+        dbCmdPb.command().add("/tmp/cassandra.pid");
         dbCmdPb.command().add("-R");
         dbCmdPb.command().add("-Dcassandra.server_process");
         dbCmdPb.command().add("-Dcassandra.skip_default_role_setup=true");
@@ -220,8 +221,12 @@ public class LifecycleResources extends BaseResources {
                 environment);
       }
 
-      if (started) logger.info("Started {}", getServerTypeName());
-      else logger.warn("Error starting {}", getServerTypeName());
+      if (started) {
+        logger.info("Started {}", getServerTypeName());
+        app.setRequestedState(STARTED);
+      } else {
+        logger.warn("Error starting {}", getServerTypeName());
+      }
 
       return Response.status(started ? HttpStatus.SC_CREATED : HttpStatus.SC_METHOD_FAILURE)
           .entity(started ? "OK\n" : String.format("Error starting %s", getServerTypeName()))
@@ -520,10 +525,8 @@ public class LifecycleResources extends BaseResources {
   }
 
   private Optional<Integer> findPid() throws IOException {
-    return UnixCmds.findDbProcessWithMatchingArg(
-        "-Ddb.unix_socket_file=" + app.dbUnixSocketFile.getAbsolutePath());
+    return UnixCmds.findPid(app.dbUnixSocketFile.getAbsolutePath());
   }
-
   /**
    * Verifies that the provided log directory can be written. Will attempt to create the directory
    * if it does not exist.

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/resources/LifecycleResources.java
@@ -124,7 +124,7 @@ public class LifecycleResources extends BaseResources {
     try {
       Optional<Integer> maybePid = findPid();
 
-      if (maybePid.isPresent()) {
+      if (maybePid.isPresent() && UnixCmds.isPidRunning(maybePid.get())) {
         return Response.status(canConnect ? HttpStatus.SC_ACCEPTED : HttpStatus.SC_NO_CONTENT)
             .build();
       } else if (canConnect) return Response.status(HttpStatus.SC_PARTIAL_CONTENT).build();
@@ -283,7 +283,7 @@ public class LifecycleResources extends BaseResources {
       } while (tries-- > 0);
 
       Optional<Integer> maybePid = findPid();
-      if (maybePid.isPresent()) {
+      if (maybePid.isPresent() && UnixCmds.isPidRunning(maybePid.get())) {
         Boolean stopped = UnixCmds.killProcess(maybePid.get());
 
         if (!stopped) {
@@ -296,7 +296,7 @@ public class LifecycleResources extends BaseResources {
         Uninterruptibles.sleepUninterruptibly(sleepSeconds, TimeUnit.SECONDS);
 
         maybePid = findPid();
-        if (maybePid.isPresent()) {
+        if (maybePid.isPresent() && UnixCmds.isPidRunning(maybePid.get())) {
           logger.info("Cassandra is not able to die");
           return Response.serverError()
               .entity(Entity.text(String.format("Killing %s Failed", getServerTypeName())))


### PR DESCRIPTION
Fixes #552 

If the state is STARTED, the liveness requires the PID file to exists and the PID that's in there to be running. 

Modify Cassandra start parameters to create the pidfile to /tmp/cassandra.pid

Fix Dockerfile validation issues from lower case "as".

Losing liveness makes Kubernetes kill the container and we start getting Terminated statuses (to properly track if Cassandra didn't for example like configuration).