### PR TITLE
Change CassandraTaskExports filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
-* [ENHANCEMENT] [#552](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/552) Improve "liveness" probe implementation
 * [FEATURE] [#551](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/551) Add Cassandra 5.0.2 to the build matrix
+* [ENHANCEMENT] [#552](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/552) Improve "liveness" probe implementation
+* [BUGFIX] [#553](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/553) Fix CassandraTaskExports metric filtering to make it work with 5.0.x Major compactions
 
 ## v0.1.87 (2024-10-02)
 * [FEATURE] [#535](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/535) Add Cassandra 5.0.0 to the build matrix

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/prometheus/CassandraTasksExports.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/prometheus/CassandraTasksExports.java
@@ -8,7 +8,6 @@ package io.k8ssandra.metrics.prometheus;
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.mgmtapi.ShimLoader;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.k8ssandra.metrics.builder.CassandraMetricDefinition;
 import io.k8ssandra.metrics.builder.CassandraMetricNameParser;

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/prometheus/CassandraTasksExports.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/prometheus/CassandraTasksExports.java
@@ -8,6 +8,7 @@ package io.k8ssandra.metrics.prometheus;
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.mgmtapi.ShimLoader;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.k8ssandra.metrics.builder.CassandraMetricDefinition;
 import io.k8ssandra.metrics.builder.CassandraMetricNameParser;
@@ -17,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.cassandra.db.compaction.OperationType;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -306,12 +306,13 @@ public class CassandraTasksExports extends Collector implements Collector.Descri
                   }
 
                   try {
-                    OperationType operationType = OperationType.valueOf(taskType.toUpperCase());
+                    // Can't use OperationType since it differs between 5.0 and 4.1
+                    String operationType = taskType.toUpperCase().replaceAll(" ", "_");
                     // Ignore taskTypes: COUNTER_CACHE_SAVE, KEY_CACHE_SAVE, ROW_CACHE_SAVE (from
                     // Cassandra 4.1)
-                    return operationType != OperationType.COUNTER_CACHE_SAVE
-                        && operationType != OperationType.KEY_CACHE_SAVE
-                        && operationType != OperationType.ROW_CACHE_SAVE;
+                    return operationType != "COUNTER_CACHE_SAVE"
+                        && operationType != "KEY_CACHE_SAVE"
+                        && operationType != "ROW_CACHE_SAVE";
                   } catch (IllegalArgumentException e) {
                     return false;
                   }


### PR DESCRIPTION
Uses String instead of OperationType for compare

And fix CHANGELOG ordering.

Fixes #553 