### PR TITLE
Add new parameter to /start, consistency. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 
+* [ENHANCEMENT] [#574](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/574) Support consistency parameter in the /start when replacing a DSE node. 
+
 ## v0.1.90 (2024-11-22)
 * [FEATURE] [#566](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/566) Add listRoles and dropRole functionality to the REST interface
 * [FEATURE] [#571](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/571) Add Cassandra 4.0.15 to the build matrix

--- a/management-api-server/doc/openapi.json
+++ b/management-api-server/doc/openapi.json
@@ -129,6 +129,12 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "in" : "query",
+          "name" : "replace_consistency",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "201" : {
@@ -150,6 +156,17 @@
           },
           "206" : {
             "description" : "Cassandra process not found but can connect"
+          },
+          "400" : {
+            "content" : {
+              "text/plain" : {
+                "example" : "Invalid replace IP passed: 0.0.0.0.0",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Invalid parameters"
           },
           "420" : {
             "content" : {

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/ManagementApplication.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/ManagementApplication.java
@@ -83,7 +83,7 @@ public class ManagementApplication extends Application {
       STATE currentState = getRequestedState();
       logger.debug("Current Requested State is {}", currentState);
       if (currentState != STATE.STOPPED) {
-        Response r = lifecycle.startNode(getActiveProfile(), null);
+        Response r = lifecycle.startNode(getActiveProfile(), null, null);
         return r.getStatus() >= 200 && r.getStatus() < 300;
       }
 


### PR DESCRIPTION
Supports -Ddse.consistent_replace=X for DSE 6.8/6.9 only

Fixes #574 

@emerkle826 I don't think we have the ability to test passed JVM parameters in the /start, at least I didn't see any existing tests for such.