### PR TITLE
Improve version management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [ENHANCEMENT] [#432](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/432) Improve version management
 
 ## v0.1.92 (2025-01-20)
 * [FEATURE] [#589](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/589) Add DSE 6.9.6 to the build matrix

--- a/management-api-agent-4.1.x/pom.xml
+++ b/management-api-agent-4.1.x/pom.xml
@@ -182,6 +182,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-4.x/pom.xml
+++ b/management-api-agent-4.x/pom.xml
@@ -179,6 +179,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-5.0.x/pom.xml
+++ b/management-api-agent-5.0.x/pom.xml
@@ -168,6 +168,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-common/pom.xml
+++ b/management-api-agent-common/pom.xml
@@ -203,6 +203,13 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
@@ -35,6 +35,8 @@ import org.slf4j.LoggerFactory;
 public class CassandraDaemonInterceptor {
   private static final Logger logger = LoggerFactory.getLogger(CassandraDaemonInterceptor.class);
   private static final String socketFileStr = System.getProperty("db.unix_socket_file");
+  private static final String apiVersion =
+      CassandraDaemonInterceptor.class.getPackage().getImplementationVersion();
 
   public static ElementMatcher<? super TypeDescription> type() {
     return ElementMatchers.nameEndsWith(".CassandraDaemon");
@@ -52,7 +54,7 @@ public class CassandraDaemonInterceptor {
 
   public static void intercept(@SuperCall Callable<Void> zuper) throws Exception {
     try {
-      logger.info("Starting DataStax Management API Agent for Apache Cassandra v0.1");
+      logger.info("Starting DataStax Management API Agent for Apache Cassandra {}", apiVersion);
 
       NodeOpsProvider.instance.get().register();
 

--- a/management-api-agent-dse-6.8/pom.xml
+++ b/management-api-agent-dse-6.8/pom.xml
@@ -173,6 +173,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-dse-6.9/pom.xml
+++ b/management-api-agent-dse-6.9/pom.xml
@@ -173,6 +173,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-hcd-1.2.x/pom.xml
+++ b/management-api-agent-hcd-1.2.x/pom.xml
@@ -164,6 +164,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-agent-hcd/pom.xml
+++ b/management-api-agent-hcd/pom.xml
@@ -164,6 +164,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.Agent</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-common/pom.xml
+++ b/management-api-common/pom.xml
@@ -142,6 +142,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>com.datastax.mgmtapi.service.Cli</Premain-Class>
+                    <Implementation-Version>${project.version}</Implementation-Version>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/management-api-server/pom.xml
+++ b/management-api-server/pom.xml
@@ -265,6 +265,9 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>com.datastax.mgmtapi.Cli</mainClass>
+                  <manifestEntries>
+                    <Implementation-Version>${project.version}</Implementation-Version>
+                  </manifestEntries>
                 </transformer>
               </transformers>
             </configuration>


### PR DESCRIPTION
This patch adds version information to the manifest of each artifact. It also updates the startup log in the Agents to log the release version instead of "v0.1" so the logs indicate more accurately which version is running.

Fixes #432