### PR TITLE
Pin QEMU binfmt image to work around a bug with ARM64 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,8 @@ jobs:
           tags: type=sha,format=long,prefix=${{ matrix.cassandra-version }}-${{ matrix.base-platform }}-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Cassandra ${{ matrix.cassandra-version }}-${{ matrix.base-platform }}
@@ -182,6 +184,8 @@ jobs:
           tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
@@ -250,6 +254,8 @@ jobs:
           tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         # buildx needs this to see local registry
@@ -318,6 +324,8 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -383,6 +391,8 @@ jobs:
         run: mvn -B -q package -DskipTests -Dskip.surefire.tests -DskipOpenApi
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -449,6 +459,8 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/nightly_image_publish.yaml
+++ b/.github/workflows/nightly_image_publish.yaml
@@ -61,6 +61,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -188,6 +190,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -242,6 +246,8 @@ jobs:
 #      - uses: actions/checkout@v4
 #      - name: Set up QEMU
 #        uses: docker/setup-qemu-action@v3
+#        with:
+#          image: tonistiigi/binfmt:qemu-v7.0.0-28
 #      - name: Setup Buildx
 #        id: buildx
 #        uses: docker/setup-buildx-action@v3
@@ -328,6 +334,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -414,6 +422,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -500,6 +510,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -564,6 +576,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -624,6 +638,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This patch pins the binfmt image used by the
setup-qemu-action to an older image to avoid a bug when building ARM64 images.

See https://github.com/docker/setup-qemu-action/issues/198 for more details.