### PR TITLE
Create notificationListener before any repairs are submitted

### DIFF
--- a/cassandra/Dockerfile-5.0.ubi8
+++ b/cassandra/Dockerfile-5.0.ubi8
@@ -50,7 +50,7 @@ COPY management-api-agent-5.0.x/target/datastax-mgmtapi-agent*.jar ./
 COPY management-api-server/target/datastax-mgmtapi-server*.jar ./
 RUN mkdir -m 775 ${MAAC_PATH} && \
     find /build -type f -name "datastax-mgmtapi*.jar" -exec mv -t $MAAC_PATH -i '{}' + && \
-    rm $MAAC_PATH/datastax-mgmtapi*test* && \
+    rm -f $MAAC_PATH/datastax-mgmtapi*test* && \
     cd ${MAAC_PATH} && \
     ln -s datastax-mgmtapi-agent*.jar datastax-mgmtapi-agent.jar && \
     ln -s datastax-mgmtapi-server*.jar datastax-mgmtapi-server.jar && \

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/util/JobExecutor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/util/JobExecutor.java
@@ -5,18 +5,100 @@
  */
 package com.datastax.mgmtapi.util;
 
+import com.datastax.mgmtapi.ShimLoader;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
+import javax.management.NotificationFilter;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.progress.ProgressEventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JobExecutor {
+  private static final Logger logger = LoggerFactory.getLogger(JobExecutor.class);
+
   ExecutorService executorService = Executors.newFixedThreadPool(1);
   Cache<String, Job> jobCache = CacheBuilder.newBuilder().recordStats().maximumSize(1000).build();
+
+  public JobExecutor() {
+    createRepairListener();
+  }
+
+  private void createRepairListener() {
+    ShimLoader.instance
+        .get()
+        .getStorageService()
+        .addNotificationListener(
+            (notification, handback) -> {
+              final int repairNo =
+                  Integer.parseInt(((String) notification.getSource()).split(":")[1]);
+
+              String jobId = String.format("repair-%d", repairNo);
+              Job job = getJobWithId(jobId);
+              if (job != null) {
+                Map<String, Integer> data = (Map<String, Integer>) notification.getUserData();
+                ProgressEventType progress = ProgressEventType.values()[data.get("type")];
+
+                switch (progress) {
+                  case START:
+                    job.setStatusChange(progress, notification.getMessage());
+                    job.setStartTime(System.currentTimeMillis());
+                    break;
+                  case NOTIFICATION:
+                  case PROGRESS:
+                    break;
+                  case ERROR:
+                  case ABORT:
+                    job.setError(new RuntimeException(notification.getMessage()));
+                    job.setStatusChange(progress, notification.getMessage());
+                    job.setStatus(Job.JobStatus.ERROR);
+                    job.setFinishedTime(System.currentTimeMillis());
+                    break;
+                  case SUCCESS:
+                    job.setStatusChange(progress, notification.getMessage());
+                    // SUCCESS / ERROR does not mean the job has completed yet (COMPLETE is that)
+                    break;
+                  case COMPLETE:
+                    job.setStatusChange(progress, notification.getMessage());
+                    job.setStatus(Job.JobStatus.COMPLETED);
+                    job.setFinishedTime(System.currentTimeMillis());
+                    break;
+                }
+                updateJob(job);
+              }
+            },
+            (NotificationFilter)
+                notification -> {
+                  if (notification == null) {
+                    return false;
+                  }
+                  logger.trace(
+                      "Received notification: {}, {}",
+                      notification.toString(),
+                      notification.getSource());
+                  if (notification.getType().equals("progress")) {
+                    // Add error handling here as well as the getType filtering, as well as matching
+                    // to some existing job
+                    try {
+                      String[] split = ((String) notification.getSource()).split(":");
+                      if (split.length > 1) {
+                        Integer.parseInt(split[1]);
+                        return true;
+                      }
+                    } catch (NumberFormatException e) {
+                      return false;
+                    }
+                  }
+                  return false;
+                },
+            null);
+  }
 
   public Pair<String, CompletableFuture<Void>> submit(String jobType, Runnable runnable) {
     // Where do I create the job details? Here? Add it to the Cache first?
@@ -42,6 +124,7 @@ public class JobExecutor {
                   return null;
                 });
 
+    logger.debug("Created a new async job {} with jobId: {}", jobType, jobId);
     return Pair.create(job.getJobId(), submittedJob);
   }
 

--- a/management-api-agent-common/src/test/java/com/datastax/mgmtapi/NodeOpsProviderTest.java
+++ b/management-api-agent-common/src/test/java/com/datastax/mgmtapi/NodeOpsProviderTest.java
@@ -36,8 +36,9 @@ public class NodeOpsProviderTest {
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
-    nodeOpsProvider = new NodeOpsProvider();
     ShimLoader.instance = () -> cassandraApi;
+    when(cassandraApi.getStorageService()).thenReturn(storageService);
+    nodeOpsProvider = new NodeOpsProvider();
     NodeOpsProvider.service = jobExecutor;
   }
 
@@ -45,7 +46,7 @@ public class NodeOpsProviderTest {
   public void testBasicRepair() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = false;
     String repairParallelism = "sequential";
     List<String> datacenters = null;
@@ -113,7 +114,7 @@ public class NodeOpsProviderTest {
   public void testIncrementalRepair() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = false;
+    boolean full = false;
     boolean notifications = false;
     String repairParallelism = "parallel";
     List<String> datacenters = null;
@@ -147,7 +148,7 @@ public class NodeOpsProviderTest {
   public void testIncrementalSequentialRepair() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = false;
+    boolean full = false;
     boolean notifications = false;
     String repairParallelism = "sequential";
     List<String> datacenters = null;
@@ -182,7 +183,7 @@ public class NodeOpsProviderTest {
   public void testRepairWithNotifications() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = true;
     String repairParallelism = "parallel";
     List<String> datacenters = null;
@@ -221,7 +222,7 @@ public class NodeOpsProviderTest {
   public void testRepairWithDatacenters() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = false;
     String repairParallelism = "parallel";
     List<String> datacenters = Arrays.asList("dc1", "dc2");
@@ -256,7 +257,7 @@ public class NodeOpsProviderTest {
   public void testRepairWithRingRange() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = false;
     String repairParallelism = "parallel";
     List<String> datacenters = null;
@@ -291,7 +292,7 @@ public class NodeOpsProviderTest {
   public void testRepairWithThreadCount() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = false;
     String repairParallelism = "parallel";
     List<String> datacenters = null;
@@ -326,7 +327,7 @@ public class NodeOpsProviderTest {
   public void testRepairWithInvalidThreadCount() throws IOException {
     String keyspace = "testKeyspace";
     List<String> tables = null;
-    Boolean full = true;
+    boolean full = true;
     boolean notifications = false;
     String repairParallelism = "parallel";
     List<String> datacenters = null;


### PR DESCRIPTION
Modify the agent to use a single listener for the repair progress status updates and create that listener before any repair jobs are scheduled