### PR TITLE
Add Cassandra 5.0.4 to the build matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -509,9 +509,9 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        cassandra-version: [5.0.1, 5.0.2, 5.0.3]
+        cassandra-version: [5.0.1, 5.0.2, 5.0.3, 5.0.4]
         include:
-          - cassandra-version: 5.0.3
+          - cassandra-version: 5.0.4
             latest: true
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [FEATURE] [#635](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/635) Add Cassandra 5.0.4 to the build matrix
+* [FEATURE] [#636](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/636) Add JDK17 for Cassandra 5.0 images
 
 ## v0.1.102 [2025-04-01]
 * [ENHANCEMENT] [#626](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/626) Bump MCAC to 0.3.6

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following versions of Cassandra and DSE are published to Docker and supporte
 | 4.0.0           | 4.1.0           | 5.0.1           | 6.8.25    | 6.9.0     | 1.1.0     | 1.2.0     |
 | 4.0.1           | 4.1.1           | 5.0.2           | 6.8.26    | 6.9.1     |           |           |
 | 4.0.3           | 4.1.2           | 5.0.3           | 6.8.28    | 6.9.2     |           |           |
-| 4.0.4           | 4.1.3           |                 | 6.8.29    | 6.9.3     |           |           |
+| 4.0.4           | 4.1.3           | 5.0.4           | 6.8.29    | 6.9.3     |           |           |
 | 4.0.5           | 4.1.4           |                 | 6.8.30    | 6.9.4     |           |           |
 | 4.0.6           | 4.1.5           |                 | 6.8.31    | 6.9.5     |           |           |
 | 4.0.7           | 4.1.6           |                 | 6.8.32    | 6.9.6     |           |           |
@@ -88,7 +88,8 @@ The following versions of Cassandra and DSE are published to Docker and supporte
 - Apache Cassandra images are available in `linux/amd64` or `linux/arm64` formats. The DSE images are available only in the `linux/amd64` format.
 - All images (with the exception of Cassandra 5.0) are available as an Ubuntu based image or a RedHat UBI 8 based image.
 Cassandra 5.0 images are only RedHat UBI8 based.
-- All Cassandra 4.0.x, 4.1.x and 5.0.x images come with JDK 11
+- All Cassandra 4.0.x and 4.1.x images come with JDK 11
+- All Cassabdra 5.0.x images come with JDK17
 - All DSE 6.8.x Ubuntu based images are available with either JDK 8 or JDK 11 (you have to pick, only  one JDK is installed in an image)
 - All DSE 6.8.x RedHat UBI 8 based images come with JDK 8
 - All DSE 6.9.x Ubuntu based images come with only JDK 11
@@ -381,7 +382,7 @@ Please see the [DSE 6.8 README](management-api-agent-dse-6.8/README.md) or the
 
 ## Code Formatting
 
-### Gogle Java Style
+### Google Java Style
 
 The project uses [google-java-format](https://github.com/google/google-java-format) and enforces the
 [Google Java Style](https://google.github.io/styleguide/javaguide.html) for all Java source files. The

--- a/cassandra-trunk/Dockerfile-trunk.ubi8
+++ b/cassandra-trunk/Dockerfile-trunk.ubi8
@@ -143,7 +143,7 @@ RUN microdnf install --nodocs shadow-utils \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
     && microdnf update && rm -rf /var/cache/yum \
 # Install packages needed during install process
-    && microdnf install --nodocs java-11-openjdk-headless tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
+    && microdnf install --nodocs java-17-openjdk-headless tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all
 
 # Copy trimmed installation

--- a/cassandra/Dockerfile-3.11
+++ b/cassandra/Dockerfile-3.11
@@ -127,7 +127,7 @@ RUN set -eux; \
   rm -rf /var/lib/apt/lists/*
 
 # backwards compat with upstream ENTRYPOINT
-COPY cassandra/scripts/docker-entrypoint.sh /usr/local/bin/
+COPY cassandra/scripts/docker-entrypoint-jdk8.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
   ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh && \
 # fix for the missing mtab in the containerd

--- a/cassandra/Dockerfile-3.11.ubi8
+++ b/cassandra/Dockerfile-3.11.ubi8
@@ -206,7 +206,7 @@ RUN (for dir in ${CASSANDRA_DATA_DIR} \
     chmod a+rwX ${MAAC_PATH} ${MCAC_PATH} ${CASSANDRA_PATH} ${CDC_AGENT_PATH} /etc/cassandra
 
 # backwards compat with upstream ENTRYPOINT
-COPY cassandra/scripts/docker-entrypoint.sh /usr/local/bin/
+COPY cassandra/scripts/docker-entrypoint-jdk8.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
   ln -sf /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh && \
 # fix for the missing mtab in the containerd

--- a/cassandra/Dockerfile-5.0.ubi8
+++ b/cassandra/Dockerfile-5.0.ubi8
@@ -1,6 +1,6 @@
 ARG UBI_MAJOR=8
 ARG UBI_BASETAG=latest
-ARG CASSANDRA_VERSION=5.0.3
+ARG CASSANDRA_VERSION=5.0.4
 FROM registry.access.redhat.com/ubi${UBI_MAJOR}/ubi-minimal:${UBI_BASETAG} AS builder
 
 ARG CASSANDRA_VERSION
@@ -91,7 +91,7 @@ RUN microdnf install --nodocs shadow-utils \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
     && microdnf update && rm -rf /var/cache/yum \
 # Install packages needed during install process
-    && microdnf install --nodocs java-11-openjdk-headless tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
+    && microdnf install --nodocs java-17-openjdk-headless tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all
 
 # Copy trimmed installation

--- a/cassandra/scripts/docker-entrypoint-jdk8.sh
+++ b/cassandra/scripts/docker-entrypoint-jdk8.sh
@@ -62,7 +62,7 @@ if [ "$1" = 'mgmtapi' ]; then
     #
     # MCAC metric filters are expected as an env variable in the following format:
     # "deny:org.apache.cassandra.metrics.table allow:org.apache.cassandra.metrics.table.test"
-    
+
     if _metrics_collector_supported && ! grep -qxF "JVM_OPTS=\"\$JVM_OPTS -javaagent:${MCAC_PATH}/lib/datastax-mcac-agent.jar\"" < ${CASSANDRA_CONF}/cassandra-env.sh ; then
         # ensure newline at end of file
         echo "" >> ${CASSANDRA_CONF}/cassandra-env.sh
@@ -196,8 +196,23 @@ if [ "$1" = 'mgmtapi' ]; then
     # use default of 128m heap if env variable not set
     : "${MGMT_API_HEAP_SIZE:=128m}"
 
-    echo "Running" java ${MGMT_API_JAVA_OPTS} -Xms${MGMT_API_HEAP_SIZE} -Xmx${MGMT_API_HEAP_SIZE} -jar "$MGMT_API_JAR" $MGMT_API_ARGS
-    java ${MGMT_API_JAVA_OPTS} -Xms${MGMT_API_HEAP_SIZE} -Xmx${MGMT_API_HEAP_SIZE} -jar "$MGMT_API_JAR" $MGMT_API_ARGS
+    # locate Java 11 for running the server
+    if [ "$JAVA11_JAVA" = "" ]; then
+        # use default Java if it reports version 11
+        DEFAULT_JAVA_VERSION=$(java -version 2>&1|awk -F '"' '/version/ {print $2}')
+        echo "Default Java version: ${DEFAULT_JAVA_VERSION}"
+        if [[ $DEFAULT_JAVA_VERSION == 11* ]]; then
+            # Java version seems to be 11
+            JAVA11_JAVA=java
+        else
+            # find java 11
+            JAVA11_HOME=$(find /usr/lib/jvm -type d -name "*java-11*")
+            echo "Found JAVA11 HOME: ${JAVA11_HOME}"
+            JAVA11_JAVA=${JAVA11_HOME}/bin/java
+        fi
+    fi
+    echo "Running" ${JAVA11_JAVA} ${MGMT_API_JAVA_OPTS} -Xms${MGMT_API_HEAP_SIZE} -Xmx${MGMT_API_HEAP_SIZE} -jar "$MGMT_API_JAR" $MGMT_API_ARGS
+    ${JAVA11_JAVA} ${MGMT_API_JAVA_OPTS} -Xms${MGMT_API_HEAP_SIZE} -Xmx${MGMT_API_HEAP_SIZE} -jar "$MGMT_API_JAR" $MGMT_API_ARGS
 fi
 
 exec "$@"


### PR DESCRIPTION
Also updates Cassandra 5.0 images to use JDK17

Fixes #635
Fixes #636
Fixes #634