### PR TITLE
Upgrade Logback dependency to 1.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [ENHANCEMENT] [#644](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/644) Upgrade Logback dependency to 1.5.13
 
 ## v0.1.103 [2025-05-03]
 * [FEATURE] [#635](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/635) Add Cassandra 5.0.4 to the build matrix

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <bytebuddy.version>1.12.19</bytebuddy.version>
     <build.version.file>build_version.sh</build.version.file>
     <slf4j.version>2.0.9</slf4j.version>
-    <logback.version>1.4.14</logback.version>
+    <logback.version>1.5.13</logback.version>
     <netty.version>4.1.119.Final</netty.version>
     <mockito.version>3.5.13</mockito.version>
     <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
This addresses CVEs:
- CVE-2024-12801
- CVE-2024-12798
- CVE-2024-12798
Fixes #644 