### PR TITLE
Add JVM client options to overwritable-conf-files for DSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [BUGFIX] [#664](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/664) Fix nodetool in readOnly root filesystems
 
 ## v0.1.106 [2025-07-25]
 * [FEATURE] [#659](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/659) Add DSE 6.9.12 to the build matrix

--- a/dse/files/overwritable-conf-files
+++ b/dse/files/overwritable-conf-files
@@ -67,6 +67,9 @@ resources/spark/conf/docker.properties.template
 resources/dse/collectd/etc/collectd/10-write-prom.conf
 resources/dse/collectd/etc/collectd/10-statsd.conf
 resources/dse/collectd/etc/collectd/10-write-graphite.conf
+resources/cassandra/conf/jvm8-clients.options
+resources/cassandra/conf/jvm-clients.options
+resources/cassandra/conf/jvm11-clients.options
 resources/cassandra/conf/jvm8-server.options
 resources/cassandra/conf/jvm-server.options
 resources/cassandra/conf/jvm11-server.options


### PR DESCRIPTION
This patch adds the clients options files so that things like nodetool work with JDK 11 and readOnlyRootFilesystem set to true

Fixes #664 