### PR TITLE
Update Netty to 4.1.127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 * [CHANGE] [#670](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/670) Update OpenJDK 11 install for UBI based images
+* [ENHANCEMENT] [#673](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/673) Update Netty to 4.1.127.Final
 
 ## v0.1.107 [2025-08-22]
 * [FEATURE] [#666](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/666) Add DSE 6.9.13 to the build matrix

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <build.version.file>build_version.sh</build.version.file>
     <slf4j.version>2.0.9</slf4j.version>
     <logback.version>1.5.13</logback.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <mockito.version>3.5.13</mockito.version>
     <prometheus.version>0.16.0</prometheus.version>
     <!-- This old version is used by Cassandra 4.x -->


### PR DESCRIPTION
This patch addresses CVE-2025-58056

Fixes #673