### PR TITLE
Bump dependencies to fix vulnerabilities (#696)

### DIFF
--- a/management-api-agent-5.0.x/pom.xml
+++ b/management-api-agent-5.0.x/pom.xml
@@ -17,7 +17,7 @@
   <artifactId>datastax-mgmtapi-agent-5.0.x</artifactId>
   <properties>
     <cassandra5.version>5.0.5</cassandra5.version>
-    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
+    <netty.http.codec.version>4.1.128.Final</netty.http.codec.version>
   </properties>
   <dependencies>
     <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->

--- a/management-api-agent-5.0.x/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
+++ b/management-api-agent-5.0.x/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
@@ -81,7 +81,7 @@ public class NettyChannelWrapper implements Channel {
   @Override
   public SocketAddress remoteAddress() {
     /**
-     * For Cassandra 5.0, and/or possibly Netty 4.1.96.Final, the remote address for the Channel
+     * For Cassandra 5.0, and/or possibly Netty 4.1.128.Final, the remote address for the Channel
      * seems to be initialized to a Netty io.netty.channel.unix.DomainSocketAddress instance. For
      * Cassandra 4.1 and lower, it seems to be null. Strangely enough, an initialized instance of
      * io.netty.channel.unix.DomainSocketAddress causes a ClassCastException in Cassandra, since it

--- a/management-api-agent-5.1.x/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
+++ b/management-api-agent-5.1.x/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
@@ -81,7 +81,7 @@ public class NettyChannelWrapper implements Channel {
   @Override
   public SocketAddress remoteAddress() {
     /**
-     * For Cassandra 5.0, and/or possibly Netty 4.1.96.Final, the remote address for the Channel
+     * For Cassandra 5.0, and/or possibly Netty 4.1.128.Final, the remote address for the Channel
      * seems to be initialized to a Netty io.netty.channel.unix.DomainSocketAddress instance. For
      * Cassandra 4.1 and lower, it seems to be null. Strangely enough, an initialized instance of
      * io.netty.channel.unix.DomainSocketAddress causes a ClassCastException in Cassandra, since it

--- a/management-api-agent-hcd-cc4/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
+++ b/management-api-agent-hcd-cc4/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
@@ -81,7 +81,7 @@ public class NettyChannelWrapper implements Channel {
   @Override
   public SocketAddress remoteAddress() {
     /**
-     * For Cassandra 5.0, and/or possibly Netty 4.1.96.Final, the remote address for the Channel
+     * For Cassandra 5.0, and/or possibly Netty 4.1.128.Final, the remote address for the Channel
      * seems to be initialized to a Netty io.netty.channel.unix.DomainSocketAddress instance. For
      * Cassandra 4.1 and lower, it seems to be null. Strangely enough, an initialized instance of
      * io.netty.channel.unix.DomainSocketAddress causes a ClassCastException in Cassandra, since it

--- a/management-api-agent-hcd-cc5/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
+++ b/management-api-agent-hcd-cc5/src/main/java/org/apache/cassandra/transport/NettyChannelWrapper.java
@@ -81,7 +81,7 @@ public class NettyChannelWrapper implements Channel {
   @Override
   public SocketAddress remoteAddress() {
     /**
-     * For Cassandra 5.0, and/or possibly Netty 4.1.96.Final, the remote address for the Channel
+     * For Cassandra 5.0, and/or possibly Netty 4.1.128.Final, the remote address for the Channel
      * seems to be initialized to a Netty io.netty.channel.unix.DomainSocketAddress instance. For
      * Cassandra 4.1 and lower, it seems to be null. Strangely enough, an initialized instance of
      * io.netty.channel.unix.DomainSocketAddress causes a ClassCastException in Cassandra, since it

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <bytebuddy.version>1.12.19</bytebuddy.version>
     <build.version.file>build_version.sh</build.version.file>
     <slf4j.version>2.0.9</slf4j.version>
-    <logback.version>1.5.13</logback.version>
+    <logback.version>1.5.19</logback.version>
     <netty.version>4.1.128.Final</netty.version>
     <mockito.version>3.5.13</mockito.version>
     <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
Fixes https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/696

```
…/playground/k8ssandra_upgrade/vuln ❯❯❯ grype k8ssandra/cass-management-api:5.0.5-ubi-patched-2 --only-fixed                                                      
 ✔ Loaded image                                                                                                                                                                      index.docker.io/k8ssandra/cass-management-api:5.0.5-ubi-patched-2
 ✔ Parsed image                                                                                                                                                                sha256:d2c2b1e133fd793e7e545799c6cc1f59fc8198dcfb34cf55ab745f72e2d79d97
 ✔ Cataloged contents                                                                                                                                                                 8a7eced0867fb75b1770656aa8b1d5f8617d91a65e611bc6498768242d152f5e
   ├── ✔ Packages                        [413 packages]
   ├── ✔ File metadata                   [6,440 locations]
   ├── ✔ File digests                    [6,440 files]
   └── ✔ Executables                     [751 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 2 high, 48 medium, 66 low, 1 negligible
   └── by status:   0 fixed, 117 not-fixed, 117 ignored
No vulnerabilities found
```


Related PR in CDC Agent:
https://github.com/datastax/cdc-apache-cassandra/pull/214