### PR TITLE
Remove microdnf update from the UBI Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 * [FEATURE] [#695](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/695) Add Cassandra 5.0.6 to the build matrix
 * [FEATURE] [#699](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/699) Add Cassandra 4.0.19 to the build matrix
+* [BUGFIX] [#700](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/700) Remove microdnf update from the Dockerfile, rely on the base image updates. This also prevents blocking due to wanting user input for upgrades
 
 ## v0.1.109 [2025-10-17]
 * [FEATURE] [#682](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/682) Add DSE 6.8.60 to the build matrix

--- a/cassandra/Dockerfile-3.11.ubi8
+++ b/cassandra/Dockerfile-3.11.ubi8
@@ -14,7 +14,7 @@ ENV CASSANDRA_HOME=/opt/cassandra
 RUN microdnf install --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install tar gzip unzip && microdnf clean all
 
@@ -55,7 +55,7 @@ ENV CASSANDRA_HOME=/opt/cassandra
 RUN microdnf install --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install tar gzip unzip && microdnf clean all
 
@@ -89,7 +89,7 @@ ENV CASSANDRA_HOME=/opt/cassandra
 RUN microdnf install --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install tar gzip unzip && microdnf clean all
 
@@ -179,7 +179,7 @@ ENV CASSANDRA_DATA_DIR=/var/lib/cassandra
 RUN microdnf install --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install --nodocs java-1.8.0-openjdk-headless java-11-openjdk-headless tzdata-java python2 python3 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all

--- a/cassandra/Dockerfile-4.0.ubi
+++ b/cassandra/Dockerfile-4.0.ubi
@@ -15,7 +15,7 @@ ENV CASSANDRA_HOME=/opt/cassandra
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install -y tar gzip unzip && microdnf clean all
 
@@ -117,7 +117,7 @@ COPY cassandra/rh-repos/adoptium.repo /etc/yum.repos.d/adoptium.repo
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install -y --nodocs temurin-11-jdk tzdata-java python3 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all

--- a/cassandra/Dockerfile-4.1.ubi
+++ b/cassandra/Dockerfile-4.1.ubi
@@ -16,7 +16,7 @@ ENV CASSANDRA_HOME=/opt/cassandra
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install -y tar gzip unzip && microdnf clean all
 
@@ -119,7 +119,7 @@ COPY cassandra/rh-repos/adoptium.repo /etc/yum.repos.d/adoptium.repo
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install -y --nodocs temurin-11-jdk tzdata-java python3 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all

--- a/cassandra/Dockerfile-5.0.ubi
+++ b/cassandra/Dockerfile-5.0.ubi
@@ -88,7 +88,7 @@ ENV CASSANDRA_FILES_PATH=/opt/cassandra_files
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
     && microdnf install -y --nodocs java-17-openjdk-headless tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all

--- a/dse/Dockerfile-dse6.8.ubi
+++ b/dse/Dockerfile-dse6.8.ubi
@@ -27,7 +27,7 @@ ENV HOME=$DSE_HOME
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install runtime dependencies and updates
-RUN microdnf update && rm -rf /var/cache/yum \
+RUN rm -rf /var/cache/yum \
     && microdnf install --nodocs -y java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel java-11-openjdk-headless python2 zlib libaio which findutils hostname iproute shadow-utils procps util-linux glibc-langpack-en wget tar && microdnf clean all
 
 WORKDIR $HOME

--- a/dse/Dockerfile-dse6.9.ubi
+++ b/dse/Dockerfile-dse6.9.ubi
@@ -29,7 +29,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 COPY dse/files/adoptium.repo /etc/yum.repos.d/adoptium.repo
 
 # Install runtime dependencies and updates
-RUN microdnf update && rm -rf /var/cache/yum && \
+RUN rm -rf /var/cache/yum && \
     microdnf install --nodocs -y temurin-11-jdk python39 zlib libaio which findutils hostname iproute shadow-utils procps util-linux glibc-langpack-en wget tar && microdnf clean all
 
 WORKDIR $HOME


### PR DESCRIPTION
Otherwise the microdnf update will block the build process if there are any updates to the base image as it wants input y/N from the user and will never finish.

Fixes #700 