### PR TITLE
Upgrade Netty to 4.1.130.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 
+* [ENHANCEMENT] [#710](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/710) Upgrade Netty to 4.1.130.Final.
+
 ## v0.1.111 [2025-12-12]
 * [BUGFIX] [#705](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/705) Fix Agent for CC5
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <build.version.file>build_version.sh</build.version.file>
     <slf4j.version>2.0.9</slf4j.version>
     <logback.version>1.5.13</logback.version>
-    <netty.version>4.1.128.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <mockito.version>3.5.13</mockito.version>
     <prometheus.version>0.16.0</prometheus.version>
     <!-- This old version is used by Cassandra 4.x -->


### PR DESCRIPTION
The rationale for this change is to remediate CVE-2025-67735.

Fixes #710