### PR TITLE
Add JFrog Maven deployment

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -17,11 +17,30 @@ on:
         options:
           - 'GitHub'
           - 'CloudsmithIO'
+          - 'Datastax'
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Generate GH API token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.K8SSANDRA_MAINTAINERS_APP_ID }}
+          private-key: ${{ secrets.K8SSANDRA_MAINTAINERS_APP_PRIVATE_KEY }}
+
+      - name: Check Maven deploy permissions
+        run: |
+          ACTOR=${{ github.actor }}
+          ORG="k8ssandra"
+          TEAM_SLUG="maintainers"
+          if ! gh api orgs/$ORG/teams/$TEAM_SLUG/members/$ACTOR >/dev/null 2>&1; then
+            echo "User $ACTOR is not a Maintainer. Exiting."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - uses: actions/checkout@v6
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -66,6 +85,11 @@ jobs:
                 <id>cloudsmith</id>
                 <username>${{ secrets.CLOUDSMITH_USERNAME }}</username>
                 <password>${{ secrets.CLOUDSMITH_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>datastax-jfrog</id>
+                <username>${{ secrets.JFROG_USERNAME }}</username>
+                <password>${{ secrets.JFROG_PASSWORD }}</password>
               </server>
            </servers>
           </settings>
@@ -115,6 +139,21 @@ jobs:
           -DaltDeploymentRepository="${REPO}" \
           -DaltSnapshotDeploymentRepository="${REPO}"
 
+      - name: Deploy Artifacts to JFrog Artifactory
+        if: |-
+          ${{
+            github.event_name != 'workflow_dispatch' ||
+            inputs.publish_repo == 'Datastax'
+          }}
+        run: |
+          REPO="datastax-jfrog::default::https://repo.datastax.com/artifactory/github-k8ssandra-management-api-local/"
+          mvn -B deploy \
+          -P dse,hcd \
+          -Dskip.surefire.tests \
+          -DskipTests \
+          -DaltDeploymentRepository="${REPO}" \
+          -DaltSnapshotDeploymentRepository="${REPO}"
+
       - name: Deploy OpenAPI client to GitHub Packages
         if: |-
           ${{
@@ -138,6 +177,21 @@ jobs:
           }}
         run: |
           REPO="cloudsmith::default::https://maven.cloudsmith.io/thelastpickle/reaper-mvn/"
+          mvn -B deploy \
+          -f management-api-server/target/generated-sources/openapi/java-client/pom.xml \
+          -Dskip.surefire.tests \
+          -DskipTests \
+          -DaltDeploymentRepository="${REPO}" \
+          -DaltSnapshotDeploymentRepository="${REPO}"
+
+      - name: Deploy OpenAPI client to JFrog Artifactory
+        if: |-
+          ${{
+            github.event_name != 'workflow_dispatch' ||
+            inputs.publish_repo == 'Datastax'
+          }}
+        run: |
+          REPO="datastax-jfrog::default::https://repo.datastax.com/artifactory/github-k8ssandra-management-api-local/"
           mvn -B deploy \
           -f management-api-server/target/generated-sources/openapi/java-client/pom.xml \
           -Dskip.surefire.tests \


### PR DESCRIPTION
This patch adds Datastax JFrog Maven artifact deployment for releases. It also adds job trigger protection such that it will not run unless a Maintainer triggers the job manuall or is the actor that pushes a tag.