### PR TITLE
Fix Metrics endpoint for HCD 2.0/CC5 Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [BUGFIX] [#739](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/739) Fix Metrics endpoint for HCD 2.0/CC5 Agent
 
 ## v0.1.115 [2026-04-02]
 * [FEATURE] [#727](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/727) Add Cassandra 5.0.7, 4.1.11 and 4.0.20 to build matrix

--- a/management-api-agent-5.0.x/pom.xml
+++ b/management-api-agent-5.0.x/pom.xml
@@ -17,7 +17,15 @@
   <artifactId>datastax-mgmtapi-agent-5.0.x</artifactId>
   <properties>
     <cassandra5.version>5.0.7</cassandra5.version>
-    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
+    <!--
+    The version here needs to match the Netty version from Cassandra upstream.
+    So when the version above changes, this may need to change to stay in sync.
+    Cassandra 5 explicitly excludes some Netty libraries from its netty-all
+    dependnecy, but the Metrics endpoint relies on netty-http-codec, so we must
+    explicitly bring it back in, but keep the version the same as the transitive
+    netty-all that we get from Cassandra
+    -->
+    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
   </properties>
   <dependencies>
     <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -37,6 +45,7 @@
       <artifactId>datastax-mgmtapi-agent-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- We need this explicitly added back in for the Metrics endpoint -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>

--- a/management-api-agent-6.0.x/pom.xml
+++ b/management-api-agent-6.0.x/pom.xml
@@ -17,7 +17,15 @@
   <artifactId>datastax-mgmtapi-agent-6.0.x</artifactId>
   <properties>
     <cassandra6.version>6.0-alpha2-SNAPSHOT</cassandra6.version>
-    <netty.http.codec.version>4.1.118.Final</netty.http.codec.version>
+    <!--
+    The version here needs to match the Netty version from Cassandra upstream.
+    So when the version above changes, this may need to change to stay in sync.
+    Cassandra 5 explicitly excludes some Netty libraries from its netty-all
+    dependnecy, but the Metrics endpoint relies on netty-http-codec, so we must
+    explicitly bring it back in, but keep the version the same as the transitive
+    netty-all that we get from Cassandra
+    -->
+    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
   </properties>
   <dependencies>
     <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -105,7 +113,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
         <executions>
           <execution>
             <phase>initialize</phase>
@@ -119,7 +126,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.4.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/management-api-agent-hcd-cc5/pom.xml
+++ b/management-api-agent-hcd-cc5/pom.xml
@@ -15,6 +15,18 @@
   </parent>
   <version>${revision}</version>
   <artifactId>datastax-mgmtapi-agent-hcd-cc5</artifactId>
+  <properties>
+    <cassandra5.version>5.0.6.0-3ba7eb526aaf</cassandra5.version>
+    <!--
+    The version here needs to match the Netty version from HCD/CC5 upstream.
+    So when the version above changes, this may need to change to stay in sync.
+    Cassandra 5 explicitly excludes some Netty libraries from its netty-all
+    dependnecy, but the Metrics endpoint relies on netty-http-codec, so we must
+    explicitly bring it back in, but keep the version the same as the transitive
+    netty-all that we get from Cassandra
+    -->
+    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
+  </properties>
   <repositories>
     <repository>
       <id>artifactory</id>
@@ -38,6 +50,12 @@
       <groupId>io.k8ssandra</groupId>
       <artifactId>datastax-mgmtapi-agent-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <!-- We need this explicitly added back in for the Metrics endpoint -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${netty.http.codec.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -69,7 +87,7 @@
         <dependency>
           <groupId>com.datastax.dse</groupId>
           <artifactId>dse-db-all</artifactId>
-          <version>5.0.6.0-3ba7eb526aaf</version>
+          <version>${cassandra5.version}</version>
           <exclusions>
             <exclusion>
               <groupId>commons-codec</groupId>


### PR DESCRIPTION
This patch adds an explicit dependnecy on netty-codec-http, which is required for the Metrics endpoints to work. This dependency has been explictly excluded in Cassandra 5, so for Agents that are based on Cassandra 5 (and newer), the netty-codec-http artifact needs to be explictly added back in. The MetricsIT test should catch this, but none of the IT tests in this project are run for HCD agents.

Fixes #739