### PR TITLE
Update ntty-codec-http version to 4.1.132.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [ENHANCEMENT] [#749](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/749) Update netty-codec-http to 4.1.132.Final for CC5
 
 ## v0.1.116 [2026-04-20]
 * [FEATURE] [#741](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/741) Add Cassandra 5.0.8 to the build matrix

--- a/management-api-agent-hcd-cc5/pom.xml
+++ b/management-api-agent-hcd-cc5/pom.xml
@@ -16,7 +16,7 @@
   <version>${revision}</version>
   <artifactId>datastax-mgmtapi-agent-hcd-cc5</artifactId>
   <properties>
-    <cassandra5.version>5.0.6.0-3ba7eb526aaf</cassandra5.version>
+    <cassandra5.version>5.0.7.0-e4706e140fc8</cassandra5.version>
     <!--
     The version here needs to match the Netty version from HCD/CC5 upstream.
     So when the version above changes, this may need to change to stay in sync.
@@ -25,7 +25,7 @@
     explicitly bring it back in, but keep the version the same as the transitive
     netty-all that we get from Cassandra
     -->
-    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
+    <netty.http.codec.version>4.1.132.Final</netty.http.codec.version>
   </properties>
   <repositories>
     <repository>


### PR DESCRIPTION
Updates the CC5 hash and the version of netty-codec-http for the CC5 agent

Fixes #749 