### PR TITLE
Fix Metrics endpoint for older Cassandra 5.0.X

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -432,7 +432,7 @@ jobs:
   test-oss-41:
     # This job is inetnded to run the various versiosn of Cassandra 4.1 where internal changes to OSS code
     # require Java refelction tricks in the Agent code.
-    name: Run Cassandra [${{ matrix.cassandra-version }}.${{ matrix.minor-version }}, ${{ matrix.base-platform }}]
+    name: Run Cassandra 4.1 Specific Tests [${{ matrix.cassandra-version }}.${{ matrix.minor-version }}, ${{ matrix.base-platform }}]
     needs: build-oss-docker-images
     runs-on: ubuntu-latest
     strategy:
@@ -485,7 +485,7 @@ jobs:
           docker buildx build --load \
             --build-arg CASSANDRA_VERSION=${{ matrix.cassandra-version }}.${{ matrix.minor-version }} \
             --tag mgmtapi-dockerfile-${{ matrix.cassandra-version }}.${{ matrix.base-platform }}-test:latest \
-            --file cassandra/Dockerfile-${{ matrix.cassandra-version }} \
+            --file cassandra/Dockerfile-${{ matrix.cassandra-version }}.ubi \
             --target cassandra .
       - name: Build with Maven and run tests Ubuntu
         if: ${{ matrix.base-platform == 'ubuntu' }}
@@ -556,7 +556,7 @@ jobs:
           docker buildx build --load \
             --build-arg CASSANDRA_VERSION=${{ matrix.cassandra-version }}.${{ matrix.minor-version }} \
             --tag mgmtapi-dockerfile-${{ matrix.cassandra-version }}.${{ matrix.base-platform }}-test:latest \
-            --file cassandra/Dockerfile-${{ matrix.cassandra-version }} \
+            --file cassandra/Dockerfile-${{ matrix.cassandra-version }}.ubi \
             --target cassandra .
       - name: Build with Maven and run tests Ubuntu
         if: ${{ matrix.base-platform == 'ubuntu' }}
@@ -570,7 +570,61 @@ jobs:
           mvn -B -q verify -Dskip.surefire.tests --file pom.xml \
           -Drun${{ matrix.cassandra-version }}testsUBI \
           -Dit.test=NodetoolIT -DfailIfNoTests=false
-          
+
+  test-oss-50:
+    # This job is inetnded to run the various versiosn of Cassandra 5.0 where Netty version conflicts
+    # with the Metrics endpoint hve caused issues (see https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/755)
+    name: Run Cassandra 5.0 Specific Tests [${{ matrix.cassandra-version }}.${{ matrix.minor-version }}]
+    needs: build-oss-docker-images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        cassandra-version: ['5.0']
+        minor-version : ['2']
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Restore Cassandra Download for tests
+        uses: actions/cache/restore@v5
+        with:
+          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra/management-api-server/.cassandra-bin
+          key: cassandra-download-${{ github.sha }}
+      - name: Build artifacts
+        run: mvn -B -q package -DskipTests -Dskip.surefire.tests -DskipOpenApi
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
+      - name: Setup Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: latest
+      - name: Build Docker test image UBI
+        run: |
+          docker buildx build --load \
+            --build-arg CASSANDRA_VERSION=${{ matrix.cassandra-version }}.${{ matrix.minor-version }} \
+            --tag mgmtapi-dockerfile-${{ matrix.cassandra-version }}.ubi-test:latest \
+            --file cassandra/Dockerfile-${{ matrix.cassandra-version }}.ubi \
+            --target cassandra .
+      - name: Build with Maven and run tests UBI
+        run: |
+          mvn -B -q verify -Dskip.surefire.tests --file pom.xml \
+          -Drun${{ matrix.cassandra-version }}testsUBI \
+          -Dit.test=Metrics50${{ matrix.minor-version }}IT -DfailIfNoTests=false
+
   test-oss-trunk:
     name: Run Cassandra ${{ matrix.itTest }} [trunk, ubi]
     needs: build-trunk-docker-images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ## unreleased
 * [ENHANCEMENT] [#752](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/752) Update Netty to 4.1.133.Final
 * [FEATURE] [#753](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/753) Add DSE 6.9.22 to the build matrix
+* [BUGFIX] [#755](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/755) Metrics endpoint broken for older Cassandra 5.0.x
 
 ## v0.1.117 [2026-04-27]
 * [ENHANCEMENT] [#749](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/749) Update netty-codec-http to 4.1.132.Final for CC5

--- a/cassandra-trunk/Dockerfile-trunk.ubi
+++ b/cassandra-trunk/Dockerfile-trunk.ubi
@@ -45,7 +45,6 @@ ARG COMMITSHA="HEAD"
 ARG CASSANDRA_BRANCH="trunk"
 ENV CASSANDRA_PATH=/opt/cassandra
 ENV CASSANDRA_FILES_PATH=/opt/cassandra_files
-WORKDIR /build
 RUN set -x \
     && git clone -b ${CASSANDRA_BRANCH} --single-branch https://github.com/apache/cassandra.git \
     && cd cassandra \
@@ -60,6 +59,24 @@ RUN set -x \
     && rm -rf ${CASSANDRA_PATH}/javadoc ${CASSANDRA_PATH}/doc \
     && chmod -R g+w ${CASSANDRA_PATH}
 COPY cassandra-trunk/files ${CASSANDRA_FILES_PATH}
+
+# Get netty-codec-http which is excluded from cassandra-all
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -x \
+    # Determine the Netty version from netty-all
+    && NETTY_VERSION=$(basename /opt/cassandra/lib/netty-all-*.jar | sed -E 's/netty-all-(.*)\.jar/\1/') \
+    # Fetch netty-codec-http into a local repo
+    && mvn -q dependency:get \
+        -DgroupId=io.netty \
+        -DartifactId=netty-codec-http \
+        -Dversion=$NETTY_VERSION \
+        -Dtransitive=false \
+        -Dmaven.repo.local=/netty/netty-codec-http/ \
+    # make the directory where we want to copy netty-codec-http jarfile
+    && mkdir -p /opt/cassandra/lib \
+    # Copy netty-codec-http
+    && cp "/netty/netty-codec-http/io/netty/netty-codec-http/$NETTY_VERSION/netty-codec-http-$NETTY_VERSION.jar" /opt/cassandra/lib/
 
 #############################################################
 # Build the Management API

--- a/cassandra/Dockerfile-5.0.ubi
+++ b/cassandra/Dockerfile-5.0.ubi
@@ -39,6 +39,36 @@ COPY --from=cassandra-base /etc/cassandra /etc/cassandra
 COPY --from=cassandra-base ${CASSANDRA_HOME} ${CASSANDRA_HOME}
 
 #############################################################
+# Get netty-codec-http which is excluded from cassandra-all
+FROM --platform=$BUILDPLATFORM maven:3-eclipse-temurin-11 AS netty-extra
+
+ARG CASSANDRA_VERSION
+
+WORKDIR /
+
+# Copy netty-all*.jar from the Cassandra lib directory from tha base Cassandra layer
+# This will let us know what version of Netty libs comes with Cassandra
+COPY --from=cassandra-base /opt/cassandra/lib/netty-all*.jar /
+
+# Use bash explicitly to allow process substitution
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -x \
+    # Determine the Netty version from the netty-all library we copied over
+    && NETTY_VERSION=$(basename /netty-all-*.jar | sed -E 's/netty-all-(.*)\.jar/\1/') \
+    # Fetch netty-codec-http into a local repo
+    && mvn -q dependency:get \
+        -DgroupId=io.netty \
+        -DartifactId=netty-codec-http \
+        -Dversion=$NETTY_VERSION \
+        -Dtransitive=false \
+        -Dmaven.repo.local=/netty/netty-codec-http/ \
+    # make the directory where we want to copy netty-codec-http jarfile
+    && mkdir -p /opt/cassandra/lib \
+    # Copy netty-codec-http
+    && cp "/netty/netty-codec-http/io/netty/netty-codec-http/$NETTY_VERSION/netty-codec-http-$NETTY_VERSION.jar" /opt/cassandra/lib/
+
+#############################################################
 # Copy Management API
 FROM --platform=$BUILDPLATFORM alpine:latest AS mgmtapi-setup
 
@@ -99,6 +129,7 @@ COPY --from=builder --chown=cassandra:root ${CASSANDRA_PATH} ${CASSANDRA_PATH}
 COPY --from=builder --chown=cassandra:root ${CASSANDRA_PATH}/LICENSE.txt /licenses/
 COPY --from=builder --chown=cassandra:root ${CDC_AGENT_PATH} ${CDC_AGENT_PATH}
 COPY --from=mgmtapi-setup --chown=cassandra:root ${MAAC_PATH} ${MAAC_PATH}
+COPY --from=netty-extra --chown=cassandra:root ${CASSANDRA_PATH}/lib ${CASSANDRA_PATH}/lib
 
 # Create directories
 RUN (for dir in ${CASSANDRA_DATA_DIR} \

--- a/management-api-agent-5.0.x/README.md
+++ b/management-api-agent-5.0.x/README.md
@@ -1,78 +1,54 @@
 # Management API for Cassandra 5.0
 
-This Maven sub-module if for building a Management API agent that works with Cassandra 5.0. Currently,
-the version in trunk is 5.1-SNAPSHOT, and the artifacts produced by this project work with 5.0.x, as well
-as the 5.1-SNAPSHOT version of Cassandra in trunk.
+This Maven sub-module if for building a Management API agent that works with Cassandra 5.0.
+For building the Agent for the latest trunk versions of Cassandra, see the README in
+management-api-agent-6.0.x.
 
 ## Building Against Published Cassandra Artifacts
 
 For Cassandra versions that have been publicly released and have Maven artifacts published, you can simply run
 the main project Maven build. The pom.xml file in this sub-module should have the `cassandra5.version` property
-set to the latest published version (`5.0.2` as of this writing). If you wish to build for a different
-published version, for example `5.0.3` when it is released, specify the version:
+set to the latest published version (`5.0.8` as of this writing). If you wish to build for a different
+published version, for example `5.0.9` when it is released, specify the version:
 
 ```sh
-mvn package -Dcassandra5.version=5.0.3
-```
-
-## Building Against Cassandra Trunk
-
-To build the agent against the latest trunk, you will need to build the Cassandra 5 Maven artifacts first and
-install them locally. This may or may not be necessary in some cases, depending on what changes have occurred
-in the Cassandra code base since the latest published version of Cassandra artifacts.
-
-### Build Prerequisites
-
-In order to build this module, you must have Cassandra trunk artifacts compiled and installed in your
-local Maven repository. Luckily, Cassandra's build has a target that will do just that: `mvn-install`.
-To setup the artifacts:
-
-1. Clone the Apache Cassandra repo locally
-
-```sh
-git clone https://github.com/apache/cassandra.git
-```
-
-2. Run the `mvn-install` target
-
-```sh
-cd cassandra
-ant mvn-install
-```
-
-This should setup your local Maven repository with the cassandra-all.jar artifacts that you will need to build the Agent.
-
-### Building the Agent
-
-As of this writing, Cassandra trunk sits at version 5.1-SNAPSHOT. So if you have followed the previous Cassandra build
-steps, you will need to override the `cassandra5.version` property when building the agent:
-
-```sh
-mvn package -Dcassandra5.version=5.1-SNAPSHOT
+mvn package -Dcassandra5.version=5.0.9
 ```
 
 ## Docker image builds
 
 As Management API releases are published, a build of this image will be available in DockerHub at:
 
-    k8ssandra/cass-management-api:5.0.2
-
-### Building Images Locally for Cassandra trunk
-
-To build a Docker image for yourself, execute the following from the root of the project:
-
-```sh
-docker buildx build --load --progress plain --tag cass-trunk --file cassandra-trunk/Dockerfile.ubi --target cass-trunk --platform linux/amd64 .
-```
-
-You can replace the tag `cass-trunk` with whatever you like.
+    k8ssandra/cass-management-api:5.0.8
 
 ## Known Limitations
+
+### MCAC Agent
 
 The latest [MCAC agent](https://github.com/datastax/metric-collector-for-apache-cassandra) does not work with Cassandra trunk.
 If you want to use this image with Docker, you must set the environment variable `MGMT_API_DISABLE_MCAC` to `true`:
 
 ```sh
-docker run -e MGMT_API_DISABLE_MCAC=true k8ssandra/cass-management-api:5.0.2
+docker run -e MGMT_API_DISABLE_MCAC=true k8ssandra/cass-management-api:5.0.8
 ```
+
+### Netty libraries for Metrics
+
+Cassandra 5.0 and newer releases have excluded `netty-codec-http` from its `netty-all` dependency. Unfortunately,
+the Metrics endpoint implementation in this project (that comes with all of the Agents) relies on this library.
+
+Normally, solving this problem would be to explicitly include `netty-codec-http` in the Agent uber jar. This creates
+a problem however in that the Agent would have to include the specific `netty-codec-http` version that matches the
+version of Netty libraries Cassandra ships with. The Cassandra Netty version is not static across all releases in a
+given `major`.`minor`, further complicating the issue.
+
+The solution is:
+- Explicitly include `netty-codec-http` in the Agent pom.xml
+- Mark `netty-codec-http` as "provided" even though it's not in all versions of Cassandra
+- Update the Docker image build to include the necessary `netty-codec-http` artifact in /opt/cassandra/lib
+
+This solution works for the images provided by this repository. However, the Agent jarfiles that are published at
+release will no longer contain this library. That means that if you use just the published Agent jarfile (and do
+not use the published Docker images), the Metrics endpoint will not work unless you also add the missing
+`netty-codec-http` library.
 

--- a/management-api-agent-5.0.x/pom.xml
+++ b/management-api-agent-5.0.x/pom.xml
@@ -17,15 +17,6 @@
   <artifactId>datastax-mgmtapi-agent-5.0.x</artifactId>
   <properties>
     <cassandra5.version>5.0.8</cassandra5.version>
-    <!--
-    The version here needs to match the Netty version from Cassandra upstream.
-    So when the version above changes, this may need to change to stay in sync.
-    Cassandra 5 explicitly excludes some Netty libraries from its netty-all
-    dependnecy, but the Metrics endpoint relies on netty-http-codec, so we must
-    explicitly bring it back in, but keep the version the same as the transitive
-    netty-all that we get from Cassandra
-    -->
-    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
   </properties>
   <dependencies>
     <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -45,11 +36,30 @@
       <artifactId>datastax-mgmtapi-agent-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>${cassandra5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>provided</scope>
+    </dependency>
     <!-- We need this explicitly added back in for the Metrics endpoint -->
+    <!-- Scope is "provided" to exclude from agent JAR (avoid CVE scans) -->
+    <!-- Docker images must add this JAR to Cassandra's lib directory -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.http.codec.version}</version>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -71,29 +81,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <!-- used by "default" and "dse" profile (dse profile is not defined in this module) -->
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.cassandra</groupId>
-          <artifactId>cassandra-all</artifactId>
-          <version>${cassandra5.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>commons-codec</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
   <build>
     <resources>
       <resource>

--- a/management-api-agent-6.0.x/README.md
+++ b/management-api-agent-6.0.x/README.md
@@ -71,6 +71,8 @@ You can replace the tag `cass-trunk` with whatever you like.
 
 ## Known Limitations
 
+### MCAC Agent
+
 The latest [MCAC agent](https://github.com/datastax/metric-collector-for-apache-cassandra) does not work with Cassandra trunk.
 If you want to use this image with Docker, you must set the environment variable `MGMT_API_DISABLE_MCAC` to `true`:
 
@@ -78,3 +80,22 @@ If you want to use this image with Docker, you must set the environment variable
 docker run -e MGMT_API_DISABLE_MCAC=true k8ssandra/cass-management-api:7.0
 ```
 
+### Netty libraries for Metrics
+
+Cassandra 5.0 and newer releases have excluded `netty-codec-http` from its `netty-all` dependency. Unfortunately,
+the Metrics endpoint implementation in this project (that comes with all of the Agents) relies on this library.
+
+Normally, solving this problem would be to explicitly include `netty-codec-http` in the Agent uber jar. This creates
+a problem however in that the Agent would have to include the specific `netty-codec-http` version that matches the
+version of Netty libraries Cassandra ships with. The Cassandra Netty version is not static across all releases in a
+given `major`.`minor`, further complicating the issue.
+
+The solution is:
+- Explicitly include `netty-codec-http` in the Agent pom.xml
+- Mark `netty-codec-http` as "provided" even though it's not in all versions of Cassandra
+- Update the Docker image build to include the necessary `netty-codec-http` artifact in /opt/cassandra/lib
+
+This solution works for the images provided by this repository. However, the Agent jarfiles that are published at
+release will no longer contain this library. That means that if you use just the published Agent jarfile (and do
+not use the published Docker images), the Metrics endpoint will not work unless you also add the missing
+`netty-codec-http` library.

--- a/management-api-agent-6.0.x/pom.xml
+++ b/management-api-agent-6.0.x/pom.xml
@@ -17,15 +17,6 @@
   <artifactId>datastax-mgmtapi-agent-6.0.x</artifactId>
   <properties>
     <cassandra.version>6.0-alpha2-SNAPSHOT</cassandra.version>
-    <!--
-    The version here needs to match the Netty version from Cassandra upstream.
-    So when the version above changes, this may need to change to stay in sync.
-    Cassandra 5 explicitly excludes some Netty libraries from its netty-all
-    dependnecy, but the Metrics endpoint relies on netty-http-codec, so we must
-    explicitly bring it back in, but keep the version the same as the transitive
-    netty-all that we get from Cassandra
-    -->
-    <netty.http.codec.version>4.1.130.Final</netty.http.codec.version>
   </properties>
   <dependencies>
     <!-- Need to explicitly declare SLF4J as "provided" to avoid it being bundled into the resulting agent jarfile -->
@@ -56,9 +47,29 @@
       <version>${bytebuddy.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>${cassandra.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>provided</scope>
+    </dependency>
+    <!-- We need this explicitly added back in for the Metrics endpoint -->
+    <!-- Scope is "provided" to exclude from agent JAR (avoid CVE scans) -->
+    <!-- Docker images must add this JAR to Cassandra's lib directory -->
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.http.codec.version}</version>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/management-api-agent-common/pom.xml
+++ b/management-api-agent-common/pom.xml
@@ -49,6 +49,22 @@
           </exclusions>
           <scope>provided</scope>
         </dependency>
+        <!-- Explicity declaring netty-codec-http as some server versions
+             exclude it from netty-all (Cassandra 5.0 and newer). We are
+             using the netty.version from the parent pom, since we have
+             to specify a version. We are also marking it "provided" so
+             we don't have it bundled into the Agent jarfile as that
+             could break thinsg if the version here doesn't match the
+             Netty version of the rest of the libraris provided by
+             Cassandra. For images we build, we will have to add this
+             artifiact in manually when Cassandra doesn't actually
+             provide it. -->
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+          <version>${netty.version}</version>
+          <scope>provided</scope>
+        </dependency>
         <dependency>
           <groupId>org.apache.cassandra</groupId>
           <artifactId>java-driver-query-builder</artifactId>

--- a/management-api-agent-hcd-cc5/pom.xml
+++ b/management-api-agent-hcd-cc5/pom.xml
@@ -43,6 +43,18 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.datastax.dse</groupId>
+      <artifactId>dse-db-all</artifactId>
+      <version>${cassandra5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
@@ -62,28 +74,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <profiles>
-    <profile>
-      <id>dse-db-all</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.datastax.dse</groupId>
-          <artifactId>dse-db-all</artifactId>
-          <version>${cassandra5.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>commons-codec</groupId>
-              <artifactId>*</artifactId>
-            </exclusion>
-          </exclusions>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
   <build>
     <resources>
       <resource>

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/Metrics502IT.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/Metrics502IT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class Metrics502IT extends MetricsIT {
+
+  public Metrics502IT(String version) throws IOException {
+    super(version);
+  }
+
+  /**
+   * Override environment variables to specify the version of Cassandra to be used. For the test in
+   * here, we want Cassandra 5.0.2 to test Netty versions.
+   *
+   * @return A list of Docker build environment variables.
+   */
+  @Override
+  protected ArrayList<String> getImageBuildArgs() {
+    ArrayList<String> list = super.getImageBuildArgs();
+    list.add("CASSANDRA_VERSION=5.0.2");
+    return list;
+  }
+}


### PR DESCRIPTION
This patch explicitly adds `netty-codec-http` as a "provided" dependency to the agent-common module and adds the library to the Docker images built for Cassandra 5.0 and newer.

The need for this is due to Cassandra 5.0 and newer excluding `netty-codec-http` from its `netty-all` dependency, but the internal Metrics implementation relies on this library. This patch also figures out which version of the library is needed in the Dockerfile updates so that we match `netty-codec-http` version with the rest of the Netty libraries that come with Cassandra. This change in the Dockerfile is due to the fact that different versions of Cassandra 5.0 include different versions of Netty, and we can't use a static `netty-codec-http` library across them all.

Fixes #755