### PR TITLE
Fix Agent for Cassandra trunk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,11 @@ jobs:
     name: Build Cassandra trunk image
     runs-on: ubuntu-latest
     needs: run-unit-tests
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        cassandra-version: ['6.0', 'trunk']
     steps:
       - name: Restore build workspace
         uses: actions/cache/restore@v5
@@ -177,29 +182,29 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: k8ssandra/cass-management-api
-          tags: type=sha,format=long,prefix=trunk-ubi-
+          tags: type=sha,format=long,prefix=${{ matrix.cassandra-version }}-ubi-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Build Cassandra Trunk UBI8
+      - name: Build Cassandra ${{ matrix.cassandra-version }} UBI
         id: docker_build_trunk
         uses: docker/build-push-action@v7
         with:
-          file: cassandra-trunk/Dockerfile-trunk.ubi
+          file: cassandra-trunk/Dockerfile-${{ matrix.cassandra-version }}.ubi
           context: .
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64
           target: cassandra
-          outputs: type=docker,dest=/tmp/cassandra.trunk.ubi.tar
-      - name: Upload Docker Image for Cassandra Trunk UBI8
+          outputs: type=docker,dest=/tmp/cassandra.${{ matrix.cassandra-version }}.ubi.tar
+      - name: Upload Docker Image for Cassandra ${{ matrix.cassandra-version }} UBI
         uses: actions/upload-artifact@v7
         with:
-          name: cassandra.trunk.ubi
-          path: /tmp/cassandra.trunk.ubi.tar
+          name: cassandra.${{ matrix.cassandra-version }}.ubi
+          path: /tmp/cassandra.${{ matrix.cassandra-version }}.ubi.tar
           retention-days: 3
           
   build-dse-ubuntu-docker-images:
@@ -626,13 +631,14 @@ jobs:
           -Dit.test=Metrics50${{ matrix.minor-version }}IT -DfailIfNoTests=false
 
   test-oss-trunk:
-    name: Run Cassandra ${{ matrix.itTest }} [trunk, ubi]
+    name: Run Cassandra ${{ matrix.itTest }} [${{ matrix.cassandra-version }}, ubi]
     needs: build-trunk-docker-images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
+        cassandra-version: ['6.0', 'trunk']
         itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
     steps:
       - uses: actions/checkout@v6
@@ -664,17 +670,17 @@ jobs:
       - name: Download Docker image
         uses: actions/download-artifact@v8
         with:
-          name: cassandra.trunk.ubi
+          name: cassandra.${{ matrix.cassandra-version }}.ubi
           path: /tmp
-      - name: Load Docker trunk-ubi image
+      - name: Load Docker ${{ matrix.cassandra-version }}-ubi image
         run: |
-          docker load --input /tmp/cassandra.trunk.ubi.tar
-          docker tag k8ssandra/cass-management-api:trunk-ubi-${{ github.sha }} mgmtapi-dockerfile-trunk.ubi-test:latest
+          docker load --input /tmp/cassandra.${{ matrix.cassandra-version }}.ubi.tar
+          docker tag k8ssandra/cass-management-api:${{ matrix.cassandra-version }}-ubi-${{ github.sha }} mgmtapi-dockerfile-${{ matrix.cassandra-version }}.ubi-test:latest
           docker image ls -a
       - name: Build with Maven and run tests
         run: |
           mvn -B -q verify -Dskip.surefire.tests --file pom.xml \
-          -DruntrunktestsUBI \
+          -Drun${{ matrix.cassandra-version }}testsUBI \
           -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false
 
   test-dse:
@@ -782,6 +788,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push'}}
     needs: test-oss-trunk
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        cassandra-version: ['6.0', 'trunk']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -793,13 +803,13 @@ jobs:
       - name: Download Docker image
         uses: actions/download-artifact@v8
         with:
-          name: cassandra.trunk.ubi
+          name: cassandra.${{ matrix.cassandra-version }}.ubi
           path: /tmp
-      - name: Load Docker trunk-ubi image
+      - name: Load Docker ${{ matrix.cassandra-version }}-ubi image
         run: |
-          docker load --input /tmp/cassandra.trunk.ubi.tar
+          docker load --input /tmp/cassandra.${{ matrix.cassandra-version }}.ubi.tar
           docker image ls -a
-          docker push k8ssandra/cass-management-api:trunk-ubi-${{ github.sha }}
+          docker push k8ssandra/cass-management-api:${{ matrix.cassandra-version }}-ubi-${{ github.sha }}
 
   publish-dse:
     name: Publish DSE 6.x Ubuntu image

--- a/.github/workflows/nightly_image_publish.yaml
+++ b/.github/workflows/nightly_image_publish.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cassandra-version: ['6.0']
+        cassandra-version: ['6.0', '7.0']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Cassandra
@@ -89,7 +89,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish scheduled ${{ matrix.cassandra-version }} to Registry
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' && matrix.cassandra-version == '7.0'}}
         id: docker_build_schedule
         uses: docker/build-push-action@v7
         with:
@@ -99,12 +99,35 @@ jobs:
           tags: ${{ steps.meta_schedule.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           target: cassandra
+      - name: Publish scheduled ${{ matrix.cassandra-version }} to Registry
+        if: ${{ github.event_name == 'schedule' && matrix.cassandra-version == '6.0'}}
+        id: docker_build_schedule
+        uses: docker/build-push-action@v7
+        with:
+          file: cassandra-trunk/Dockerfile-6.0.ubi
+          context: .
+          push: true
+          tags: ${{ steps.meta_schedule.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          target: cassandra
       - name: Publish on-demand ${{ matrix.cassandra-version }} to Registry
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.cassandra-version == '7.0'}}
         id: docker_build_on_demand
         uses: docker/build-push-action@v7
         with:
           file: cassandra-trunk/Dockerfile-trunk.ubi
+          context: .
+          push: true
+          tags: ${{ steps.meta_on_demand.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          target: cassandra
+          build-args: COMMITSHA=${{ env.COMMITSHA }}, CASSANDRA_BRANCH=${{ env.CASSANDRA_BRANCH }}
+      - name: Publish on-demand ${{ matrix.cassandra-version }} to Registry
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.cassandra-version == '6.0'}}
+        id: docker_build_on_demand
+        uses: docker/build-push-action@v7
+        with:
+          file: cassandra-trunk/Dockerfile-6.0.ubi
           context: .
           push: true
           tags: ${{ steps.meta_on_demand.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 * [FEATURE] [#763](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/763) Add DSE 6.9.23 to the build matrix
 * [ENHANCEMENT] [#761](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/761) Remove Cassandra 3.11 files
 * [ENHANCEMENT] [#759](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/759) Update Netty to 4.1.135.Final
+* [BUGFIX] [#746](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/746) Fix Agent for Cassandra trunk
 
 ## v0.1.119
 * [FEATURE] [#757](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/757) Add DSE 6.8.64 to the build matrix

--- a/cassandra-trunk/Dockerfile-6.0.ubi
+++ b/cassandra-trunk/Dockerfile-6.0.ubi
@@ -1,6 +1,6 @@
 ARG UBI_MAJOR=10
 ARG UBI_BASETAG=latest
-ARG CASSANDRA_VERSION=7.0-SNAPSHOT
+ARG CASSANDRA_VERSION=6.0-alpha2-SNAPSHOT
 ARG JDK_MAJOR=17
 ARG JDK_VERSION=${JDK_MAJOR}.0.19
 ARG JDK_BUILD=10
@@ -33,6 +33,7 @@ ARG JDK_BUILD
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV CASSANDRA_HOME=/opt/cassandra
+ENV JAVA_HOME=/opt/jdk
 
 # Update base layer
 RUN microdnf install -y --nodocs shadow-utils \
@@ -75,7 +76,7 @@ RUN set -x \
 FROM --platform=$BUILDPLATFORM cass-builder-base AS cass-builder
 ARG CASSANDRA_VERSION
 ARG COMMITSHA="HEAD"
-ARG CASSANDRA_BRANCH="trunk"
+ARG CASSANDRA_BRANCH="cassandra-6.0"
 ENV CASSANDRA_PATH=/opt/cassandra
 ENV CASSANDRA_FILES_PATH=/opt/cassandra_files
 RUN set -x \
@@ -133,7 +134,7 @@ COPY management-api-server/pom.xml /tmp/management-api-server/pom.xml
 COPY management-api-test/pom.xml /tmp/management-api-test/pom.xml
 # this duplicates work done in the next steps, but this should provide
 # a solid cache layer that only gets reset on pom.xml changes
-RUN cd /tmp && mvn -q -ff -T 1C package -Dskip.surefire.tests -DskipTests -DskipOpenApi -Dcassandra.version=7.0-SNAPSHOT -P trunk && rm -rf target
+RUN cd /tmp && mvn -q -ff -T 1C package -Dskip.surefire.tests -DskipTests -DskipOpenApi -P trunk && rm -rf target
 
 COPY management-api-agent-shaded-libs /tmp/management-api-agent-shaded-libs
 COPY management-api-agent-common /tmp/management-api-agent-common
@@ -145,7 +146,7 @@ COPY management-api-common /tmp/management-api-common
 COPY management-api-server /tmp/management-api-server
 RUN mkdir -m 775 ${MAAC_PATH} \
     && cd /tmp \
-    && mvn -q -ff package -Dskip.surefire.tests -DskipTests -DskipOpenApi -Dcassandra.version=7.0-SNAPSHOT -P trunk \
+    && mvn -q -ff package -Dskip.surefire.tests -DskipTests -DskipOpenApi -P trunk \
     && find /tmp -type f -name "datastax-*.jar" -exec mv -t ${MAAC_PATH} -i '{}' + \
     && rm ${MAAC_PATH}/datastax-mgmtapi-agent-4.x* \
     && rm ${MAAC_PATH}/datastax-mgmtapi-agent-4.1.x* \

--- a/cassandra-trunk/Dockerfile-6.0.ubi
+++ b/cassandra-trunk/Dockerfile-6.0.ubi
@@ -1,4 +1,4 @@
-ARG UBI_MAJOR=10
+ARG UBI_MAJOR=9
 ARG UBI_BASETAG=latest
 ARG CASSANDRA_VERSION=6.0-alpha2-SNAPSHOT
 ARG JDK_MAJOR=17
@@ -194,13 +194,15 @@ ENV JAVA_HOME=/opt/jdk
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update -y && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
-    && microdnf install -y --nodocs tzdata-java python3.12 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
+    && microdnf install -y --nodocs tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all -y \
     # Setup JDK
     && update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 100 \
-    && update-alternatives --set java ${JAVA_HOME}/bin/java
+    && update-alternatives --set java ${JAVA_HOME}/bin/java \
+    # Lynk Python
+    && ln -sT /usr/bin/python3.11 /usr/bin/python
 
 # Copy trimmed installation
 COPY --from=cass-builder --chown=cassandra:root ${CASSANDRA_PATH} ${CASSANDRA_PATH}

--- a/cassandra-trunk/Dockerfile-trunk.ubi
+++ b/cassandra-trunk/Dockerfile-trunk.ubi
@@ -1,4 +1,4 @@
-ARG UBI_MAJOR=10
+ARG UBI_MAJOR=9
 ARG UBI_BASETAG=latest
 ARG CASSANDRA_VERSION=7.0-SNAPSHOT
 ARG JDK_MAJOR=17
@@ -193,13 +193,15 @@ ENV JAVA_HOME=/opt/jdk
 RUN microdnf install -y --nodocs shadow-utils \
     && groupadd -r cassandra --gid=999 \
     && useradd -m -d "$CASSANDRA_HOME" -r -g cassandra -G root --uid=999 cassandra \
-    && microdnf update -y && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum \
 # Install packages needed during install process
-    && microdnf install -y --nodocs tzdata-java python3.12 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
+    && microdnf install -y --nodocs tzdata-java python3.11 zlib findutils which hostname iproute procps util-linux glibc-langpack-en wget tar \
     && microdnf clean all -y \
     # Setup JDK
     && update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 100 \
-    && update-alternatives --set java ${JAVA_HOME}/bin/java
+    && update-alternatives --set java ${JAVA_HOME}/bin/java \
+    # Lynk Python
+    && ln -sT /usr/bin/python3.11 /usr/bin/python
 
 # Copy trimmed installation
 COPY --from=cass-builder --chown=cassandra:root ${CASSANDRA_PATH} ${CASSANDRA_PATH}

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/CassandraAPIServiceProvider60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/CassandraAPIServiceProvider60x.java
@@ -5,13 +5,13 @@
  */
 package com.datastax.mgmtapi;
 
-import com.datastax.mgmtapi.shim.CassandraAPI51x;
+import com.datastax.mgmtapi.shim.CassandraAPI60x;
 import com.datastax.mgmtapi.shims.CassandraAPI;
 
-public class CassandraAPIServiceProvider51x implements CassandraAPIServiceProvider {
+public class CassandraAPIServiceProvider60x implements CassandraAPIServiceProvider {
 
   @Override
   public CassandraAPI getCassandraAPI() {
-    return new CassandraAPI51x();
+    return new CassandraAPI60x();
   }
 }

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/GenericSerializer60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/GenericSerializer60x.java
@@ -30,7 +30,7 @@ import org.apache.cassandra.serializers.TypeSerializer;
  * Uses reflection to look up an appropriate TypeSerializer/AbstractType to serialize objects
  * without writing annoying ByteBufferUtil.bytes(X/Y/Z) boilerplate.
  */
-class GenericSerializer51x {
+class GenericSerializer60x {
   /**
    * I considered using the drivers code (CodecRegistry, TypeCodec, etc) but decided that it made
    * more sense to use the server side stuff from Cassandra.

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/ObjectSerializer60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/ObjectSerializer60x.java
@@ -25,7 +25,7 @@ import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 
-public class ObjectSerializer51x<T> implements ObjectSerializer<T> {
+public class ObjectSerializer60x<T> implements ObjectSerializer<T> {
   public final ImmutableSortedMap<String, FieldSerializer> serializers;
 
   public class FieldSerializer {
@@ -64,11 +64,11 @@ public class ObjectSerializer51x<T> implements ObjectSerializer<T> {
    * the double types. Also, this will only serialize **PUBLIC** fields (perhaps this should be
    * changed; it's not totally clear). Tag accordingly.
    */
-  public ObjectSerializer51x(Class<T> clazz, Type genericType) {
+  public ObjectSerializer60x(Class<T> clazz, Type genericType) {
     serializers =
-        GenericSerializer51x.simpleType(genericType)
+        GenericSerializer60x.simpleType(genericType)
             ? ImmutableSortedMap.<String, FieldSerializer>of(
-                "result", new FieldSerializer(GenericSerializer51x.getType(genericType), x -> x))
+                "result", new FieldSerializer(GenericSerializer60x.getType(genericType), x -> x))
             : ImmutableSortedMap.copyOf(
                 Arrays.stream(clazz.getFields())
                     .collect(
@@ -76,11 +76,11 @@ public class ObjectSerializer51x<T> implements ObjectSerializer<T> {
                             field -> field.getName(),
                             field ->
                                 new FieldSerializer(
-                                    GenericSerializer51x.getType(field.getGenericType()), field))));
+                                    GenericSerializer60x.getType(field.getGenericType()), field))));
     // currently not recursive; multiple ways to do it
   }
 
-  public ObjectSerializer51x(Class<T> clazz) {
+  public ObjectSerializer60x(Class<T> clazz) {
     this(clazz, clazz);
   }
 
@@ -103,7 +103,10 @@ public class ObjectSerializer51x<T> implements ObjectSerializer<T> {
                             new ColumnIdentifier(e.getKey(), true),
                             e.getValue().type))
                 .collect(Collectors.toList())),
-        Lists.<List<ByteBuffer>>newArrayList(toByteBufferList(obj)));
+        Lists.<List<byte[]>>newArrayList(
+            toByteBufferList(obj).stream()
+                .map(bb -> bb == null ? null : bb.array())
+                .collect(Collectors.toList())));
   }
 
   /**
@@ -125,7 +128,13 @@ public class ObjectSerializer51x<T> implements ObjectSerializer<T> {
                             new ColumnIdentifier(e.getKey(), true),
                             e.getValue().type))
                 .collect(Collectors.toList())),
-        obj.stream().map(this::toByteBufferList).collect(Collectors.toList()));
+        obj.stream()
+            .map(
+                o ->
+                    toByteBufferList(o).stream()
+                        .map(bb -> bb == null ? null : bb.array())
+                        .collect(Collectors.toList()))
+            .collect(Collectors.toList()));
   }
 
   public List<ByteBuffer> toByteBufferList(T obj) {

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/RpcMethod60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/RpcMethod60x.java
@@ -30,19 +30,19 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RpcMethod51x implements RpcMethod {
-  private static final Logger logger = LoggerFactory.getLogger(RpcMethod51x.class);
+public class RpcMethod60x implements RpcMethod {
+  private static final Logger logger = LoggerFactory.getLogger(RpcMethod60x.class);
   private final Method method;
   private final RpcObject rpcObject;
   private final String name;
   private final List<TypeSerializer> argSerializers;
   private final List<AbstractType> argTypes;
   private final List<String> argNames;
-  private final ObjectSerializer51x retSerializer;
+  private final ObjectSerializer60x retSerializer;
   private final OptionalInt clientStateArgIdx;
   private final List<Pair<Integer, RpcParam>> params;
 
-  <R> RpcMethod51x(Method method, RpcObject rpcObject) {
+  <R> RpcMethod60x(Method method, RpcObject rpcObject) {
     this.method = method;
     this.rpcObject = rpcObject;
     this.name = method.getAnnotation(Rpc.class).name();
@@ -78,12 +78,12 @@ public class RpcMethod51x implements RpcMethod {
     Type[] genericParamTypes = method.getGenericParameterTypes();
     this.argSerializers =
         params.stream()
-            .map(p -> GenericSerializer51x.getSerializer(genericParamTypes[p.getKey()]))
+            .map(p -> GenericSerializer60x.getSerializer(genericParamTypes[p.getKey()]))
             .collect(Collectors.toList());
 
     this.argTypes =
         params.stream()
-            .map(p -> GenericSerializer51x.getTypeOrException(genericParamTypes[p.getKey()]))
+            .map(p -> GenericSerializer60x.getTypeOrException(genericParamTypes[p.getKey()]))
             .collect(Collectors.toList());
 
     this.argNames = params.stream().map(p -> p.getValue().name()).collect(Collectors.toList());
@@ -97,10 +97,10 @@ public class RpcMethod51x implements RpcMethod {
       Preconditions.checkArgument(
           elemType instanceof Class<?>,
           "If multi-row result set is request, the element type must be a Class");
-      this.retSerializer = new ObjectSerializer51x<>((Class<?>) elemType);
+      this.retSerializer = new ObjectSerializer60x<>((Class<?>) elemType);
     } else {
       this.retSerializer =
-          new ObjectSerializer51x<>(method.getReturnType(), method.getGenericReturnType());
+          new ObjectSerializer60x<>(method.getReturnType(), method.getGenericReturnType());
     }
   }
 

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/RpcMethodServiceProvider60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/rpc/RpcMethodServiceProvider60x.java
@@ -7,10 +7,10 @@ package com.datastax.mgmtapi.rpc;
 
 import java.lang.reflect.Method;
 
-public class RpcMethodServiceProvider51x implements RpcMethodServiceProvider {
+public class RpcMethodServiceProvider60x implements RpcMethodServiceProvider {
 
   @Override
   public RpcMethod getRpcMethod(Method method, RpcObject rpcObject) {
-    return new RpcMethod51x(method, rpcObject);
+    return new RpcMethod60x(method, rpcObject);
   }
 }

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/CassandraAPI60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/CassandraAPI60x.java
@@ -49,7 +49,7 @@ import org.apache.cassandra.locator.Endpoints;
 import org.apache.cassandra.locator.EndpointsForRange;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.locator.K8SeedProvider51x;
+import org.apache.cassandra.locator.K8SeedProvider60x;
 import org.apache.cassandra.locator.ReplicaPlans;
 import org.apache.cassandra.locator.SeedProvider;
 import org.apache.cassandra.schema.KeyspaceMetadata;
@@ -65,17 +65,17 @@ import org.apache.cassandra.tcm.compatibility.TokenRingUtils;
 import org.apache.cassandra.tcm.membership.Location;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.transport.Server;
-import org.apache.cassandra.transport.UnixSocketServer51x;
+import org.apache.cassandra.transport.UnixSocketServer60x;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CassandraAPI51x implements CassandraAPI {
-  private static final Logger logger = LoggerFactory.getLogger(CassandraAPI51x.class);
+public class CassandraAPI60x implements CassandraAPI {
+  private static final Logger logger = LoggerFactory.getLogger(CassandraAPI60x.class);
 
   private static final Supplier<SeedProvider> seedProvider =
-      Suppliers.memoize(() -> new K8SeedProvider51x());
+      Suppliers.memoize(() -> new K8SeedProvider60x());
 
   @Override
   public void enableFullQuerylog() {
@@ -308,7 +308,7 @@ public class CassandraAPI51x implements CassandraAPI {
   @Override
   public ChannelInitializer<Channel> makeSocketInitializer(
       Server.ConnectionTracker connectionTracker) {
-    return UnixSocketServer51x.makeSocketInitializer(connectionTracker);
+    return UnixSocketServer60x.makeSocketInitializer(connectionTracker);
   }
 
   @Override
@@ -418,7 +418,7 @@ public class CassandraAPI51x implements CassandraAPI {
 
   @Override
   public RpcStatementShim makeRpcStatement(String method, String[] params) {
-    return new RpcStatement51x(method, params);
+    return new RpcStatement60x(method, params);
   }
 
   @Override

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
@@ -13,11 +13,11 @@ import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.messages.ResultMessage;
 
-public class RpcStatement51x implements RpcStatementShim {
+public class RpcStatement60x implements RpcStatementShim {
   private final String method;
   private final String[] params;
 
-  public RpcStatement51x(String method, String[] params) {
+  public RpcStatement60x(String method, String[] params) {
     this.method = method;
     this.params = params;
   }

--- a/management-api-agent-6.0.x/src/main/java/org/apache/cassandra/locator/K8SeedProvider60x.java
+++ b/management-api-agent-6.0.x/src/main/java/org/apache/cassandra/locator/K8SeedProvider60x.java
@@ -17,10 +17,10 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class K8SeedProvider51x implements SeedProvider {
-  private static final Logger logger = LoggerFactory.getLogger(K8SeedProvider51x.class);
+public class K8SeedProvider60x implements SeedProvider {
+  private static final Logger logger = LoggerFactory.getLogger(K8SeedProvider60x.class);
 
-  public K8SeedProvider51x() {}
+  public K8SeedProvider60x() {}
 
   public List<InetAddressAndPort> getSeeds() {
     Config conf;

--- a/management-api-agent-6.0.x/src/main/java/org/apache/cassandra/transport/UnixSocketServer60x.java
+++ b/management-api-agent-6.0.x/src/main/java/org/apache/cassandra/transport/UnixSocketServer60x.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UnixSocketServer51x {
+public class UnixSocketServer60x {
   private static final Logger logger = LoggerFactory.getLogger(IPCController.class);
 
   // Names of handlers used in pre-V5 pipelines

--- a/management-api-agent-6.0.x/src/main/resources/META-INF/services/com.datastax.mgmtapi.CassandraAPIServiceProvider
+++ b/management-api-agent-6.0.x/src/main/resources/META-INF/services/com.datastax.mgmtapi.CassandraAPIServiceProvider
@@ -1,1 +1,1 @@
-com.datastax.mgmtapi.CassandraAPIServiceProvider51x
+com.datastax.mgmtapi.CassandraAPIServiceProvider60x

--- a/management-api-agent-6.0.x/src/main/resources/META-INF/services/com.datastax.mgmtapi.rpc.RpcMethodServiceProvider
+++ b/management-api-agent-6.0.x/src/main/resources/META-INF/services/com.datastax.mgmtapi.rpc.RpcMethodServiceProvider
@@ -1,1 +1,1 @@
-com.datastax.mgmtapi.rpc.RpcMethodServiceProvider51x
+com.datastax.mgmtapi.rpc.RpcMethodServiceProvider60x

--- a/management-api-agent-6.0.x/src/test/java/com/datastax/mgmtapi/rpc/ObjectSerializer60xTest.java
+++ b/management-api-agent-6.0.x/src/test/java/com/datastax/mgmtapi/rpc/ObjectSerializer60xTest.java
@@ -7,16 +7,16 @@ package com.datastax.mgmtapi.rpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ObjectSerializer51xTest
-    extends ObjectSerializerTestBase<ObjectSerializer51x<Example>> {
+public class ObjectSerializer60xTest
+    extends ObjectSerializerTestBase<ObjectSerializer60x<Example>> {
 
   @Override
-  protected ObjectSerializer51x<Example> createExampleSerializer() {
-    return new ObjectSerializer51x<>(Example.class);
+  protected ObjectSerializer60x<Example> createExampleSerializer() {
+    return new ObjectSerializer60x<>(Example.class);
   }
 
   @Override
-  protected String getCqlType(ObjectSerializer51x<Example> serializer, String fieldName) {
+  protected String getCqlType(ObjectSerializer60x<Example> serializer, String fieldName) {
     assertThat(serializer.serializers).containsKey(fieldName);
     return serializer.serializers.get(fieldName).type.toString();
   }

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -114,6 +114,7 @@ public abstract class BaseDockerIntegrationTest {
     if (Boolean.getBoolean("run4.1tests")) versions.add("4_1");
     if (Boolean.getBoolean("run4.1testsUBI")) versions.add("4_1_ubi");
     if (Boolean.getBoolean("run5.0testsUBI")) versions.add("5_0_ubi");
+    if (Boolean.getBoolean("run6.0testsUBI")) versions.add("6_0_ubi");
     if (Boolean.getBoolean("runtrunktestsUBI")) versions.add("trunk_ubi");
     if (Boolean.getBoolean("runDSE6.8tests")) versions.add("dse-68");
     if (Boolean.getBoolean("runDSE6.8testsUBI")) versions.add("dse-68_ubi");

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/BaseDockerIntegrationTest.java
@@ -107,8 +107,6 @@ public abstract class BaseDockerIntegrationTest {
   public static List<String> testVersions() {
     List<String> versions = new ArrayList<>(4);
 
-    if (Boolean.getBoolean("run3.11tests")) versions.add("3_11");
-    if (Boolean.getBoolean("run3.11testsUBI")) versions.add("3_11_ubi");
     if (Boolean.getBoolean("run4.0tests")) versions.add("4_0");
     if (Boolean.getBoolean("run4.0testsUBI")) versions.add("4_0_ubi");
     if (Boolean.getBoolean("run4.1tests")) versions.add("4_1");
@@ -245,9 +243,6 @@ public abstract class BaseDockerIntegrationTest {
   }
 
   protected int getNumTokenRanges() {
-    if (this.version.startsWith("3")) {
-      return 256;
-    }
     if (this.version.startsWith("dse")) {
       return 1;
     }
@@ -255,6 +250,9 @@ public abstract class BaseDockerIntegrationTest {
       return 16;
     }
     if (this.version.startsWith("5")) {
+      return 16;
+    }
+    if (this.version.startsWith("6")) {
       return 16;
     }
     if (this.version.startsWith("trunk")) {

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
@@ -452,6 +452,14 @@ public class DockerHelper {
               Lists.newArrayList(
                   "MAX_HEAP_SIZE=500M", "HEAP_NEWSIZE=100M", "MGMT_API_DISABLE_MCAC=true");
           break;
+        case "6_0_ubi":
+          config.dockerFile =
+              Paths.get(config.baseDir.getPath(), "cassandra-trunk", "Dockerfile-6.0.ubi").toFile();
+          config.target = "cassandra";
+          config.envList =
+              Lists.newArrayList(
+                  "MAX_HEAP_SIZE=500M", "HEAP_NEWSIZE=100M", "MGMT_API_DISABLE_MCAC=true");
+          break;
         case "trunk_ubi":
           config.dockerFile =
               Paths.get(config.baseDir.getPath(), "cassandra-trunk", "Dockerfile-trunk.ubi")

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
@@ -408,18 +408,6 @@ public class DockerHelper {
         String version, List<String> envVars, String user, List<String> buildVars) {
       DockerBuildConfig config = new DockerBuildConfig();
       switch (version) {
-        case "3_11":
-          config.dockerFile =
-              Paths.get(config.baseDir.getPath(), "cassandra", "Dockerfile-3.11").toFile();
-          config.target = "cassandra";
-          config.envList = Lists.newArrayList("MAX_HEAP_SIZE=500M", "HEAP_NEWSIZE=100M");
-          break;
-        case "3_11_ubi":
-          config.dockerFile =
-              Paths.get(config.baseDir.getPath(), "cassandra", "Dockerfile-3.11.ubi").toFile();
-          config.target = "cassandra";
-          config.envList = Lists.newArrayList("MAX_HEAP_SIZE=500M", "HEAP_NEWSIZE=100M");
-          break;
         case "4_0":
           config.dockerFile =
               Paths.get(config.baseDir.getPath(), "cassandra", "Dockerfile-4.0").toFile();


### PR DESCRIPTION
This patch fixes the class names of the Cassandra 6.0 Agent module as well as fixing the ObjectSerializer failures for both 6.0 and trunk (7.0).

Fixes #746 