### PR TITLE
Publish the DSE images to a private icr.io registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -207,78 +207,11 @@ jobs:
           path: /tmp/cassandra.${{ matrix.cassandra-version }}.ubi.tar
           retention-days: 3
           
-  build-dse-ubuntu-docker-images:
-    name: Build DSE Ubuntu images
+  build-and-test-dse:
+    name: Build and Test DSE ${{ matrix.itTest }} [${{ matrix.dse-version }}, ${{ matrix.base-platform }}]
     runs-on: ubuntu-latest
     needs: run-unit-tests
-    strategy:
-      fail-fast: false
-      max-parallel: 8
-      matrix:
-        dse-version: ['6.8', '6.9']
-        base-platform: ['jdk8', 'jdk11']
-        exclude:
-          - dse-version: '6.9'
-            base-platform: 'jdk8'
-    steps:
-      - name: Restore build workspace
-        uses: actions/cache/restore@v5
-        with:
-          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra
-          key: ${{ runner.os }}-workspace-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: 11
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      # Setup metadata based on the commit/tag that will be used for tagging the image
-      # Only build and publish a commit based tag
-      - name: Setup Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: datastax/dse-mgmtapi-6_8
-          tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
-        id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
-          context: .
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64
-          target: dse
-          outputs: type=docker,dest=/tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-      - name: Upload Docker Image for DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}
-          path: /tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-          retention-days: 3
-
-  build-dse-ubi-docker-images:
-    name: Build DSE UBI images
-    needs: build-dse-ubuntu-docker-images
-    runs-on: ubuntu-latest
-    # need a local docker registry to push images into
+    # need a local docker registry to push images into for UBI builds
     services:
       registry:
         image: registry:2
@@ -289,13 +222,15 @@ jobs:
       max-parallel: 8
       matrix:
         dse-version: ['6.8', '6.9']
-        base-platform: ['ubi']
-        include:
-          - dse-version: '6.8'
-            jdk: 'jdk8'
+        base-platform: ['jdk8', 'jdk11', 'ubi']
+        itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'DSESpecificIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
+        exclude:
           - dse-version: '6.9'
-            jdk: 'jdk11'
+            base-platform: 'jdk8'
+          - dse-version: '6.8'
+            base-platform: 'jdk11'
     steps:
+      - uses: actions/checkout@v6
       - name: Restore build workspace
         uses: actions/cache/restore@v5
         with:
@@ -312,56 +247,86 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      # Setup metadata based on the commit/tag that will be used for tagging the image
-      # Only build and publish a commit based tag
-      - name: Setup Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Restore Cassandra Download for tests
+        uses: actions/cache/restore@v5
         with:
-          images: datastax/dse-mgmtapi-6_8
-          tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
+          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra/management-api-server/.cassandra-bin
+          key: cassandra-download-${{ github.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
-        # buildx needs this to see local registry
         with:
-          driver-opts: network=host
-      - name: Download DSE ${{ matrix.dse-version }} ${{ matrix.jdk }} base Docker image
-        uses: actions/download-artifact@v8
+          driver-opts: ${{ matrix.base-platform == 'ubi' && 'network=host' || '' }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
         with:
-          name: dse.${{ matrix.dse-version }}.${{ matrix.jdk }}
-          path: /tmp
-      - name: Load Docker ${{ matrix.dse-version }}-${{ matrix.jdk }} image
-        run: |
-          docker load --input /tmp/dse.${{ matrix.dse-version }}.${{ matrix.jdk }}.tar
-          # tag with the local registry prefix
-          docker tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.jdk }}-${{ github.sha }} localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.jdk }}-${{ github.sha }}
-          docker push localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.jdk }}-${{ github.sha }}
-          docker image ls -a
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      
+      # Build Ubuntu-based images (jdk8, jdk11)
       - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
-        id: docker_build
+        if: ${{ matrix.base-platform != 'ubi' }}
+        uses: docker/build-push-action@v7
+        with:
+          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
+          context: .
+          push: false
+          load: true
+          tags: mgmtapi-dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}-test:latest
+          platforms: linux/amd64
+          target: dse
+      
+      # Build UBI images (requires base Ubuntu image first)
+      - name: Build DSE ${{ matrix.dse-version }} base for UBI
+        if: ${{ matrix.base-platform == 'ubi' }}
+        uses: docker/build-push-action@v7
+        with:
+          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}
+          context: .
+          push: false
+          tags: localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          platforms: linux/amd64
+          target: dse
+          outputs: type=docker
+      
+      - name: Push base image to local registry for UBI build
+        if: ${{ matrix.base-platform == 'ubi' }}
+        run: |
+          docker push localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+      
+      - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
+        if: ${{ matrix.base-platform == 'ubi' }}
         uses: docker/build-push-action@v7
         with:
           file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
           context: .
           build-contexts: |
-            builder=docker-image://localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.jdk }}-${{ github.sha }}
+            builder=docker-image://localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
+          load: true
+          tags: mgmtapi-dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}-test:latest
           platforms: linux/amd64
           target: dse
-          # override the base pull image to be the local one we built and tagged above
-          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.jdk }}-${{ github.sha }}
-          outputs: type=docker,dest=/tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-      - name: Upload Docker Image for DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}
-          path: /tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-          retention-days: 3
+          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+      
+      # Run tests
+      - name: Setup Maven settings.xml
+        run: |
+          cp ~/.m2/settings.xml settings.xml
+      - name: Build with Maven and run tests
+        if: ${{ matrix.base-platform != 'ubi' }}
+        run: |
+          mvn -B -q verify -Dskip.surefire.tests --file pom.xml -P dse -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false \
+          -DrunDSE${{ matrix.dse-version }}tests
+      - name: Build with Maven and run tests
+        if: ${{ matrix.base-platform == 'ubi' }}
+        run: |
+          mvn -B -q verify -Dskip.surefire.tests --file pom.xml -P dse -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false \
+          -DrunDSE${{ matrix.dse-version }}testsUBI
 
   test-oss:
     name: Run Cassandra ${{ matrix.itTest }} [${{ matrix.cassandra-version }}, ${{ matrix.base-platform }}]
@@ -683,73 +648,6 @@ jobs:
           -Drun${{ matrix.cassandra-version }}testsUBI \
           -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false
 
-  test-dse:
-    name: Run DSE ${{ matrix.itTest }} [${{ matrix.dse-version }}, ${{ matrix.base-platform }}]
-    # if: github.repository_owner == 'k8ssandra'
-    runs-on: ubuntu-latest
-    needs: build-dse-ubi-docker-images
-    strategy:
-      fail-fast: false
-      max-parallel: 8
-      matrix:
-        dse-version: ['6.8', '6.9']
-        base-platform: ['jdk8', 'jdk11', 'ubi']
-        itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'DSESpecificIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
-        exclude:
-          - dse-version: '6.9'
-            base-platform: 'jdk8'
-          - dse-version: '6.8'
-            base-platform: 'jdk11'
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: 11
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Restore Cassandra Download for tests
-        uses: actions/cache/restore@v5
-        with:
-          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra/management-api-server/.cassandra-bin
-          key: cassandra-download-${{ github.sha }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
-      - name: Setup Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          version: latest
-      - name: Download Docker image
-        uses: actions/download-artifact@v8
-        with:
-          name: dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}
-          path: /tmp
-      - name: Load Docker ${{ matrix.dse-version }}-${{ matrix.base-platform }} image
-        run: |
-          docker load --input /tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-          docker tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.base-platform }}-${{ github.sha }} mgmtapi-dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}-test:latest
-          docker image ls -a
-      - name: Setup Maven settings.xml
-        run: |
-          cp ~/.m2/settings.xml settings.xml
-      - name: Build with Maven and run tests
-        if: ${{ matrix.base-platform != 'ubi' }}
-        run: |
-          mvn -B -q verify -Dskip.surefire.tests --file pom.xml -P dse -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false \
-          -DrunDSE${{ matrix.dse-version }}tests
-      - name: Build with Maven and run tests
-        if: ${{ matrix.base-platform == 'ubi' }}
-        run: |
-          mvn -B -q verify -Dskip.surefire.tests --file pom.xml -P dse -Dit.test=${{ matrix.itTest }} -DfailIfNoTests=false \
-          -DrunDSE${{ matrix.dse-version }}testsUBI
 
   publish-oss:
     name: Publish ${{ matrix.cassandra-version }} Cassandra image
@@ -812,10 +710,16 @@ jobs:
           docker push k8ssandra/cass-management-api:${{ matrix.cassandra-version }}-ubi-${{ github.sha }}
 
   publish-dse:
-    name: Publish DSE 6.x Ubuntu image
+    name: Publish DSE 6.x image to ICR
     if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push'}}
-    needs: test-dse
+    needs: build-and-test-dse
     runs-on: ubuntu-latest
+    # need a local docker registry to push images into for UBI builds
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       matrix:
         dse-version: ['6.8', '6.9']
@@ -826,20 +730,89 @@ jobs:
           - dse-version: '6.8'
             base-platform: 'jdk11'
     steps:
+      - name: Restore build workspace
+        uses: actions/cache/restore@v5
+        with:
+          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra
+          key: ${{ runner.os }}-workspace-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Setup Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: icr.io/ds-mission-control-private/dse-mgmtapi-6_8
+          tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: ${{ matrix.base-platform == 'ubi' && 'network=host' || '' }}
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Download Docker image
-        uses: actions/download-artifact@v8
+      - id: docker-login-icr
+        uses: docker/login-action@v3
         with:
-          name: dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}
-          path: /tmp
-      - name: Load Docker ${{ matrix.dse-version }}-${{ matrix.base-platform }} image
+          username: iamapikey
+          password: ${{ secrets.PRIVATE_ICR_API_KEY }}
+          registry: icr.io
+      
+      # Rebuild images for publishing (same as in build-and-test-dse)
+      # Build Ubuntu-based images (jdk8, jdk11)
+      - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
+        if: ${{ matrix.base-platform != 'ubi' }}
+        uses: docker/build-push-action@v7
+        with:
+          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          target: dse
+      
+      # Build UBI images (requires base Ubuntu image first)
+      - name: Build DSE ${{ matrix.dse-version }} base for UBI
+        if: ${{ matrix.base-platform == 'ubi' }}
+        uses: docker/build-push-action@v7
+        with:
+          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}
+          context: .
+          push: false
+          tags: localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          platforms: linux/amd64
+          target: dse
+          outputs: type=docker
+      
+      - name: Push base image to local registry for UBI build
+        if: ${{ matrix.base-platform == 'ubi' }}
         run: |
-          docker load --input /tmp/dse.${{ matrix.dse-version }}.${{ matrix.base-platform }}.tar
-          docker image ls -a
-          docker push datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.base-platform }}-${{ github.sha }}
+          docker push localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+      
+      - name: Build and push DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
+        if: ${{ matrix.base-platform == 'ubi' }}
+        uses: docker/build-push-action@v7
+        with:
+          file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
+          context: .
+          build-contexts: |
+            builder=docker-image://localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          target: dse
+          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,11 +231,6 @@ jobs:
             base-platform: 'jdk11'
     steps:
       - uses: actions/checkout@v6
-      - name: Restore build workspace
-        uses: actions/cache/restore@v5
-        with:
-          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra
-          key: ${{ runner.os }}-workspace-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:
@@ -247,6 +242,32 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Setup Maven settings file
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+      - name: Build Maven artifacts
+        run: mvn -B -q package -DskipTests -Dskip.surefire.tests -DskipOpenApi -P dse
       - name: Restore Cassandra Download for tests
         uses: actions/cache/restore@v5
         with:
@@ -730,11 +751,7 @@ jobs:
           - dse-version: '6.8'
             base-platform: 'jdk11'
     steps:
-      - name: Restore build workspace
-        uses: actions/cache/restore@v5
-        with:
-          path: /home/runner/work/management-api-for-apache-cassandra/management-api-for-apache-cassandra
-          key: ${{ runner.os }}-workspace-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
+      - uses: actions/checkout@v6
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:
@@ -746,6 +763,32 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ github.sha }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Setup Maven settings file
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings>
+            <servers>
+              <server>
+                <id>artifactory-snapshots</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory-releases</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>artifactory</id>
+                <username>${{ secrets.ARTIFACTORY_USERNAME }}</username>
+                <password>${{ secrets.ARTIFACTORY_PASSWORD }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+      - name: Build Maven artifacts
+        run: mvn -B -q package -DskipTests -Dskip.surefire.tests -DskipOpenApi -P dse
       - name: Setup Docker meta
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,7 +214,7 @@ jobs:
     # need a local docker registry to push images into for UBI builds
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
     strategy:
@@ -738,7 +738,7 @@ jobs:
     # need a local docker registry to push images into for UBI builds
     services:
       registry:
-        image: registry:2
+        image: registry:3
         ports:
           - 5000:5000
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -809,7 +809,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - id: docker-login-icr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: iamapikey
           password: ${{ secrets.PRIVATE_ICR_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           version: latest
       - id: docker-login-icr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: iamapikey
           password: ${{ secrets.PRIVATE_ICR_API_KEY }}
@@ -275,7 +275,7 @@ jobs:
         with:
           version: latest
       - id: docker-login-icr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: iamapikey
           password: ${{ secrets.PRIVATE_ICR_API_KEY }}
@@ -656,7 +656,7 @@ jobs:
         with:
           version: latest
       - id: docker-login-icr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: iamapikey
           password: ${{ secrets.PRIVATE_ICR_API_KEY }}
@@ -742,7 +742,7 @@ jobs:
         with:
           version: latest
       - id: docker-login-icr
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: iamapikey
           password: ${{ secrets.PRIVATE_ICR_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - id: docker-login-icr
         uses: docker/login-action@v4
         with:
@@ -274,6 +279,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - id: docker-login-icr
         uses: docker/login-action@v4
         with:
@@ -655,6 +665,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - id: docker-login-icr
         uses: docker/login-action@v4
         with:
@@ -741,6 +756,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - id: docker-login-icr
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,22 +147,23 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+      - id: docker-login-icr
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          username: iamapikey
+          password: ${{ secrets.PRIVATE_ICR_API_KEY }}
+          registry: icr.io
       - if: ${{ matrix.latest && matrix.image-base == 'jdk8' }}
         name: Publish ${{ matrix.dse-version }} (${{ matrix.image-base }}) to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:6.8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -172,9 +173,9 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -184,10 +185,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -197,8 +198,8 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -273,23 +274,24 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+      - id: docker-login-icr
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          username: iamapikey
+          password: ${{ secrets.PRIVATE_ICR_API_KEY }}
+          registry: icr.io
       - if: ${{ matrix.latest }}
         name: Publish ${{ matrix.dse-version }} (ubi) to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:6.8-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -299,10 +301,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -653,21 +655,22 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+      - id: docker-login-icr
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          username: iamapikey
+          password: ${{ secrets.PRIVATE_ICR_API_KEY }}
+          registry: icr.io
       - if: ${{ matrix.latest }}
         name: Publish ${{ matrix.dse-version }} (${{ matrix.image-base }}) to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:6.9 \
-            --tag datastax/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -677,8 +680,8 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -738,23 +741,24 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: latest
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+      - id: docker-login-icr
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          username: iamapikey
+          password: ${{ secrets.PRIVATE_ICR_API_KEY }}
+          registry: icr.io
       - if: ${{ matrix.latest }}
         name: Publish ${{ matrix.dse-version }} (ubi) to Registry
         run: |
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:6.9-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -764,10 +768,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag datastax/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .

--- a/dse/Dockerfile-dse6.8.ubi
+++ b/dse/Dockerfile-dse6.8.ubi
@@ -1,7 +1,7 @@
 ARG DSE_VERSION=6.8.64
 ARG UBI_MAJOR=8
 ARG UBI_BASETAG=latest
-ARG DSE_BASE_IMAGE=datastax/dse-mgmtapi-6_8:${DSE_VERSION}
+ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${DSE_VERSION}
 
 FROM ${DSE_BASE_IMAGE} AS dse-server-base
 

--- a/dse/Dockerfile-dse6.9.ubi
+++ b/dse/Dockerfile-dse6.9.ubi
@@ -1,7 +1,7 @@
 ARG DSE_VERSION=6.9.23
 ARG UBI_MAJOR=9
 ARG UBI_BASETAG=latest
-ARG DSE_BASE_IMAGE=datastax/dse-mgmtapi-6_8:${DSE_VERSION}-jdk11
+ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${DSE_VERSION}-jdk11
 
 FROM ${DSE_BASE_IMAGE} AS dse-server-base
 


### PR DESCRIPTION
Refactor CI/CD: Migrate DSE images to private ICR registry and eliminate artifacts

Changes:

CI Workflow (.github/workflows/ci.yaml):
- Merged build-dse-ubuntu-docker-images, build-dse-ubi-docker-images, and
  test-dse jobs into a single build-and-test-dse job
- Build and test now run in the same job/runner, eliminating the need for
  artifact-based image transfer between jobs
- Images are built, tested, and discarded within each test job
- Updated publish-dse job to rebuild images and push directly to
  icr.io
- Removed all artifact upload/download steps for DSE images