### PR TITLE
change the DSE 6.8/6.9 images to be named dse-mgmtapi instead of dse-mgmtapi-6_8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,7 +309,7 @@ jobs:
           file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}
           context: .
           push: false
-          tags: localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          tags: localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
           platforms: linux/amd64
           target: dse
           outputs: type=docker
@@ -317,7 +317,7 @@ jobs:
       - name: Push base image to local registry for UBI build
         if: ${{ matrix.base-platform == 'ubi' }}
         run: |
-          docker push localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          docker push localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
       
       - name: Build DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
         if: ${{ matrix.base-platform == 'ubi' }}
@@ -326,13 +326,13 @@ jobs:
           file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
           context: .
           build-contexts: |
-            builder=docker-image://localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+            builder=docker-image://localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
           push: false
           load: true
           tags: mgmtapi-dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}-test:latest
           platforms: linux/amd64
           target: dse
-          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
       
       # Run tests
       - name: Setup Maven settings.xml
@@ -793,7 +793,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: icr.io/ds-mission-control-private/dse-mgmtapi-6_8
+          images: icr.io/ds-mission-control-private/dse-mgmtapi
           tags: type=sha,format=long,prefix=${{ matrix.dse-version }}-${{ matrix.base-platform }}-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -836,7 +836,7 @@ jobs:
           file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}
           context: .
           push: false
-          tags: localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          tags: localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
           platforms: linux/amd64
           target: dse
           outputs: type=docker
@@ -844,7 +844,7 @@ jobs:
       - name: Push base image to local registry for UBI build
         if: ${{ matrix.base-platform == 'ubi' }}
         run: |
-          docker push localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          docker push localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
       
       - name: Build and push DSE ${{ matrix.dse-version }}-${{ matrix.base-platform }}
         if: ${{ matrix.base-platform == 'ubi' }}
@@ -853,9 +853,9 @@ jobs:
           file: dse/Dockerfile-dse${{ matrix.dse-version }}.${{ matrix.base-platform }}
           context: .
           build-contexts: |
-            builder=docker-image://localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+            builder=docker-image://localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64
           target: dse
-          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-6_8-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}
+          build-args: DSE_BASE_IMAGE=localhost:5000/dse-mgmtapi-${{ matrix.dse-version }}-${{ matrix.dse-version == '6.8' && 'jdk8' || 'jdk11' }}-${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,11 +164,11 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -178,9 +178,9 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.8-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -190,10 +190,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -203,8 +203,8 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -296,12 +296,12 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.8-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.8-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.8-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -311,10 +311,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.8.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -682,10 +682,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.9 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.9-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -695,8 +695,8 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -773,12 +773,12 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:6.9-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.9-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:6.9-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .
@@ -788,10 +788,10 @@ jobs:
           RELEASE_VERSION="${GITHUB_REF##*/}"
           docker buildx build --push \
             --build-arg DSE_VERSION=${{ matrix.dse-version }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }} \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8 \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
-            --tag icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }} \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8 \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-${{ matrix.image-base }}-$RELEASE_VERSION \
+            --tag icr.io/ds-mission-control-private/dse-mgmtapi:${{ matrix.dse-version }}-ubi8-$RELEASE_VERSION \
             --file dse/Dockerfile-dse6.9.${{ matrix.image-base }} \
             --target dse \
             --platform linux/amd64 .

--- a/README.md
+++ b/README.md
@@ -168,33 +168,33 @@ Example for Cassandra 4.0.10
 
 For all JDK 8 Ubuntu based DSE 6.8.x images, the Docker coordinates are as follows:
 
-      datastax/dse-mgmtapi-6_8:<version>
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>
 
 Example for DSE 6.8.31
 
-      datastax/dse-mgmtapi-6_8:6.8.31
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:6.8.31
 
 For all JDK 11 Ubuntu based DSE 6.8.x images, the Docker coordinates are as follows:
 
-      datastax/dse-mgmtapi-6_8:<version>-jdk11
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-jdk11
 
 Example for DSE 6.8.31
 
-      datastax/dse-mgmtapi-6_8:6.8.31-jdk11
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:6.8.31-jdk11
 
 #### RedHat UBI based images (DSE 6.8)
 
 For all RedHat UBI based DSE 6.8.x images, the Docker coordinates are as follows:
 
-      datastax/dse-mgmtapi-6_8:<version>-ubi
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-ubi
 
 For legacy tagging conventions, the image is also tagged as:
 
-      datastax/dse-mgmtapi-6_8:<version>-ubi8
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-ubi8
 
 Example for DSE 6.8.31
 
-      datastax/dse-mgmtapi-6_8:6.8.31-ubi
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:6.8.31-ubi
 
 ### Docker coordinates for DSE 6.9.x images
 
@@ -202,27 +202,27 @@ Example for DSE 6.8.31
 
 For all JDK 11 Ubuntu based DSE 6.8.x images, the Docker coordinates are as follows:
 
-      datastax/dse-mgmtapi-6_8:<version>-jdk11
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-jdk11
 
 Example for DSE 6.9.0
 
-      datastax/dse-mgmtapi-6_8:6.9.0-jdk11
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:6.9.0-jdk11
 
 #### RedHat UBI based images (DSE 6.9)
 
 For all RedHat UBI based DSE 6.9.x images, the Docker coordinates are as follows:
 
-      datastax/dse-mgmtapi-6_8:<version>-ubi
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-ubi
 
 For legacy tagging conventions, the image is also tagged as:
 
-      datastax/dse-mgmtapi-6_8:<version>-ubi8
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:<version>-ubi8
 
 Example for DSE 6.9.0
 
-      datastax/dse-mgmtapi-6_8:6.9.0-ubi
+      cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi:6.9.0-ubi
 
-** NOTE 1: The docker repo is not a typo, it really is `datastax/dse-mgmtapi-6_8` for 6.9 images
+** NOTE 1: The docker repo is not a typo, it really is `cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi` for 6.9 images
 ** NOTE 2: While the Legacy tagging uses `ubi8`, the image as of v0.1.108 is actually UBI 9 based
 
 ### Docker coordinates for HCD 1.1.x/1.2.x images

--- a/dse/Dockerfile-dse6.8.ubi
+++ b/dse/Dockerfile-dse6.8.ubi
@@ -1,7 +1,7 @@
 ARG DSE_VERSION=6.8.64
 ARG UBI_MAJOR=8
 ARG UBI_BASETAG=latest
-ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${DSE_VERSION}
+ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi:${DSE_VERSION}
 
 FROM ${DSE_BASE_IMAGE} AS dse-server-base
 

--- a/dse/Dockerfile-dse6.9.ubi
+++ b/dse/Dockerfile-dse6.9.ubi
@@ -1,7 +1,7 @@
 ARG DSE_VERSION=6.9.23
 ARG UBI_MAJOR=9
 ARG UBI_BASETAG=latest
-ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi-6_8:${DSE_VERSION}-jdk11
+ARG DSE_BASE_IMAGE=icr.io/ds-mission-control-private/dse-mgmtapi:${DSE_VERSION}-jdk11
 
 FROM ${DSE_BASE_IMAGE} AS dse-server-base
 

--- a/management-api-agent-dse-6.8/README.md
+++ b/management-api-agent-dse-6.8/README.md
@@ -40,7 +40,11 @@ to DockerHub at:
 Images built from this repo are for testing changes to Management API prior to releasing new versions and integrating them into
 official DSE images. Images built from this repo will be published to DockerHub at:
 
-    datastax/dse-mgmtapi-6_8
+    icr.io/ds-mission-control-private/dse-mgmtapi
+
+Upon promotion, they will be available through the IBM entitled registry:
+
+    cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi
 
 ### Building DSE images locally
 

--- a/management-api-agent-dse-6.9/README.md
+++ b/management-api-agent-dse-6.9/README.md
@@ -40,7 +40,11 @@ to DockerHub at:
 Images built from this repo are for testing changes to Management API prior to releasing new versions and integrating them into
 official DSE images. Images built from this repo will be published to DockerHub at:
 
-    datastax/dse-mgmtapi-6_8
+    icr.io/ds-mission-control-private/dse-mgmtapi
+
+Upon promotion, they will be available through the IBM entitled registry:
+
+    cp.icr.io/cp/ibm-ds-mission-control/dse-mgmtapi
 
 ### Building DSE images locally
 


### PR DESCRIPTION
Since we're changing locations, it felt right to remove the `6_8` from the image names since we're also publishing 6.9 images.