### PR TITLE
Update DSE repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ```
 
 ## unreleased
+* [BUGFIX] [#770](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/770) Use Public Datastax repos
+
+## v0.1.122 [2026-07-03]
+* [CHANGE] Rename the dse images from dse-mgmtapi-6_8 to dse-mgmtapi
+
 
 ## v0.1.121 [2026-06-16]
 * [CHANGE] Relocate DSE images publishing to icr.io

--- a/management-api-agent-dse-6.8/pom.xml
+++ b/management-api-agent-dse-6.8/pom.xml
@@ -22,11 +22,11 @@
     </repository>
     <repository>
       <id>artifactory-snapshots</id>
-      <url>https://repo.datastax.com/datastax-snapshots-local</url>
+      <url>https://repo.datastax.com/dse</url>
     </repository>
     <repository>
       <id>artifactory-releases</id>
-      <url>https://repo.datastax.com/datastax-releases-local</url>
+      <url>https://repo.datastax.com/dse</url>
     </repository>
   </repositories>
   <properties>

--- a/management-api-agent-dse-6.9/pom.xml
+++ b/management-api-agent-dse-6.9/pom.xml
@@ -22,11 +22,11 @@
     </repository>
     <repository>
       <id>artifactory-snapshots</id>
-      <url>https://repo.datastax.com/datastax-snapshots-local</url>
+      <url>https://repo.datastax.com/dse</url>
     </repository>
     <repository>
       <id>artifactory-releases</id>
-      <url>https://repo.datastax.com/datastax-releases-local</url>
+      <url>https://repo.datastax.com/dse</url>
     </repository>
   </repositories>
   <properties>


### PR DESCRIPTION
This pacth changes the DSE artifactory repos to the full public DSE repos. This will fix issues like:

```
[9](https://github.com/k8ssandra/management-api-for-apache-cassandra/actions/runs/28651840606/job/84972239949#step:7:30)
Error:  Failed to execute goal on project datastax-mgmtapi-agent-dse-6.8: Could not resolve dependencies for project io.k8ssandra:datastax-mgmtapi-agent-dse-6.8:jar:0.1.122
Error:  dependency: org.codehaus.jackson:jackson-core-asl:jar:1.9.13.1.dse (provided)
Error:  	Could not find artifact org.codehaus.jackson:jackson-core-asl:jar:1.9.13.1.dse in central (https://repo.maven.apache.org/maven2)
Error:  	Could not find artifact org.codehaus.jackson:jackson-core-asl:jar:1.9.13.1.dse in artifactory-snapshots (https://repo.datastax.com/datastax-snapshots-local)
Error:  	Could not find artifact org.codehaus.jackson:jackson-core-asl:jar:1.9.13.1.dse in artifactory-releases (https://repo.datastax.com/datastax-releases-local)
Error:  dependency: org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13.1.dse (provided)
Error:  	Could not find artifact org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13.1.dse in central (https://repo.maven.apache.org/maven2)
Error:  	Could not find artifact org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13.1.dse in artifactory-snapshots (https://repo.datastax.com/datastax-snapshots-local)
Error:  	Could not find artifact org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13.1.dse in artifactory-releases (https://repo.datastax.com/datastax-releases-local)
Error:  
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :datastax-mgmtapi-agent-dse-6.8
Error: Process completed with exit code 1.
```

Fixes #770 