### PR TITLE
Set default AuditLogContext for RpcStatements used by mgmt-api. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 * [BUGFIX] [#770](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/770) Use Public Datastax repos
+* [BUGFIX] [#309](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/309) Set default AuditLogContext for the RpcStatements that is by default hidden
 
 ## v0.1.122 [2026-07-03]
 * [CHANGE] Rename the dse images from dse-mgmtapi-6_8 to dse-mgmtapi

--- a/management-api-agent-4.1.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement41x.java
+++ b/management-api-agent-4.1.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement41x.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -51,7 +52,7 @@ public class RpcStatement41x implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override

--- a/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -39,7 +40,7 @@ public class RpcStatement implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override

--- a/management-api-agent-5.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement50x.java
+++ b/management-api-agent-5.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement50x.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -41,7 +42,7 @@ public class RpcStatement50x implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -41,7 +42,7 @@ public class RpcStatement60x implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override

--- a/management-api-agent-hcd-cc4/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-hcd-cc4/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -36,7 +37,7 @@ public class RpcStatement implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override

--- a/management-api-agent-hcd-cc5/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-hcd-cc5/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
 import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -50,7 +51,7 @@ public class RpcStatement implements RpcStatementShim {
 
   @Override
   public AuditLogContext getAuditLogContext() {
-    return null;
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", method);
   }
 
   @Override


### PR DESCRIPTION
These audit logs should be hidden by default because of the filtering in Cassandra itself:

https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/audit/AuditLogOptions.java#L45

This should hopefully fix the NPE, but I'm not sure if we run into some other issue later..

Fixes #309 