### PR TITLE
Fix Audit Log exceptions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,17 @@ jobs:
       matrix:
         dse-version: ['6.8', '6.9']
         base-platform: ['jdk8', 'jdk11', 'ubi']
-        itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'DSESpecificIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
+        itTest :
+          - 'LifecycleIT'
+          - 'KeepAliveIT'
+          - 'NonDestructiveOpsIT'
+          - 'DestructiveOpsIT'
+          - 'DSESpecificIT'
+          - 'NonDestructiveOpsResourcesV2IT'
+          - 'DockerImageIT'
+          - 'AsyncRepairIT'
+          - 'PortOverrideIT'
+          - 'MetricsIT'
         exclude:
           - dse-version: '6.9'
             base-platform: 'jdk8'
@@ -359,7 +369,17 @@ jobs:
       matrix:
         cassandra-version: ['4.0', '4.1', '5.0']
         base-platform: ['ubuntu', 'ubi']
-        itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
+        itTest :
+          - 'LifecycleIT'
+          - 'KeepAliveIT'
+          - 'NonDestructiveOpsIT'
+          - 'DestructiveOpsIT'
+          - 'NonDestructiveOpsResourcesV2IT'
+          - 'DockerImageIT'
+          - 'AsyncRepairIT'
+          - 'PortOverrideIT'
+          - 'MetricsIT'
+          - 'AuditLogIT'
         exclude:
           - cassandra-version: '5.0'
             base-platform: 'ubuntu'
@@ -625,7 +645,17 @@ jobs:
       max-parallel: 4
       matrix:
         cassandra-version: ['6.0', 'trunk']
-        itTest : ['LifecycleIT', 'KeepAliveIT', 'NonDestructiveOpsIT', 'DestructiveOpsIT', 'NonDestructiveOpsResourcesV2IT', 'DockerImageIT', 'AsyncRepairIT', 'PortOverrideIT', 'MetricsIT']
+        itTest :
+          - 'LifecycleIT'
+          - 'KeepAliveIT'
+          - 'NonDestructiveOpsIT'
+          - 'DestructiveOpsIT'
+          - 'NonDestructiveOpsResourcesV2IT'
+          - 'DockerImageIT'
+          - 'AsyncRepairIT'
+          - 'PortOverrideIT'
+          - 'MetricsIT'
+          - 'AuditLogIT'
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 
 ## unreleased
 * [BUGFIX] [#770](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/770) Use Public Datastax repos
+* [BUGFIX] [#309](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/309) Set default AuditLogContext for the RpcStatements that is by default hidden
 
 ## v0.1.122 [2026-07-03]
 * [CHANGE] Rename the dse images from dse-mgmtapi-6_8 to dse-mgmtapi

--- a/management-api-agent-4.1.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement41x.java
+++ b/management-api-agent-4.1.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement41x.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -47,11 +46,6 @@ public class RpcStatement41x implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-4.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -35,11 +34,6 @@ public class RpcStatement implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-agent-5.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement50x.java
+++ b/management-api-agent-5.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement50x.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -37,11 +36,6 @@ public class RpcStatement50x implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
+++ b/management-api-agent-6.0.x/src/main/java/com/datastax/mgmtapi/shim/RpcStatement60x.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -37,11 +36,6 @@ public class RpcStatement60x implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-agent-hcd-cc4/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-hcd-cc4/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -32,11 +31,6 @@ public class RpcStatement implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-agent-hcd-cc5/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
+++ b/management-api-agent-hcd-cc5/src/main/java/com/datastax/mgmtapi/shim/RpcStatement.java
@@ -6,7 +6,6 @@
 package com.datastax.mgmtapi.shim;
 
 import com.datastax.mgmtapi.shims.RpcStatementShim;
-import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -46,11 +45,6 @@ public class RpcStatement implements RpcStatementShim {
   @Override
   public ResultMessage executeLocally(QueryState queryState, QueryOptions queryOptions) {
     return new ResultMessage.Void();
-  }
-
-  @Override
-  public AuditLogContext getAuditLogContext() {
-    return null;
   }
 
   @Override

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/shims/RpcStatementShim.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/shims/RpcStatementShim.java
@@ -5,10 +5,17 @@
  */
 package com.datastax.mgmtapi.shims;
 
+import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.CQLStatement;
 
 public interface RpcStatementShim extends CQLStatement {
   String getMethod();
 
   String[] getParams();
+
+  @Override
+  default AuditLogContext getAuditLogContext() {
+    return new AuditLogContext(AuditLogEntryType.SELECT, "system", getMethod());
+  }
 }

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/AuditLogIT.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/AuditLogIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi;
+
+import static com.datastax.mgmtapi.BaseDockerIntegrationTest.BASE_PATH;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import com.datastax.mgmtapi.helpers.IntegrationTestUtils;
+import com.datastax.mgmtapi.helpers.NettyHttpClient;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AuditLogIT extends BaseDockerIsolatedIntegrationTest {
+
+  public AuditLogIT(String version) throws IOException {
+    super(version);
+  }
+
+  @Test
+  public void testAuditLogs() throws IOException, InterruptedException {
+    assumeTrue(IntegrationTestUtils.shouldRun() && !this.version.startsWith("dse"));
+
+    boolean ready = false;
+    NettyHttpClient client;
+    try {
+      client = getClient();
+
+      // Configure
+      boolean configured =
+          client
+              .post(
+                  URI.create(BASE_PATH + "/lifecycle/configure?profile=auditlogtest").toURL(),
+                  FileUtils.readFileToString(
+                      IntegrationTestUtils.getFile(this.getClass(), "audit-log-test.yaml")),
+                  "application/yaml")
+              .thenApply(r -> r.status().code() == HttpStatus.SC_OK)
+              .join();
+
+      assertTrue(configured);
+
+      // Startup
+      boolean started =
+          client
+              .post(URI.create(BASE_PATH + "/lifecycle/start?profile=auditlogtest").toURL(), null)
+              .thenApply(r -> r.status().code() == HttpStatus.SC_CREATED)
+              .join();
+
+      assertTrue(started);
+
+      int tries = 0;
+      while (tries++ < 10) {
+        ready =
+            client
+                .get(URI.create(BASE_PATH + "/probes/readiness").toURL())
+                .thenApply(r -> r.status().code() == HttpStatus.SC_OK)
+                .join();
+
+        if (ready) {
+          break;
+        }
+
+        Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+      }
+
+      assertTrue(ready);
+
+      // make API call to get endpoints
+      client
+          .get(URI.create(BASE_PATH + "/metadata/endpoints").toURL())
+          .thenApply(r -> r.status().code() == HttpStatus.SC_OK)
+          .join();
+
+      String systemLogTail = "EMPTY";
+      try {
+        systemLogTail = docker.runCommandWithOutput("tail", "-50", "/var/log/cassandra/system.log");
+        docker.runCommand(
+            "grep", "-in", "\"Failed notifying listeners\"", "/var/log/cassandra/system.log");
+      } catch (IOException ioe) {
+        // grep should NOt find anything and thus will fail with a non-zero rc
+      } catch (Throwable t) {
+        // running commands failed some way other than a non-zero rc
+        System.err.println("Tail of system.log\n" + systemLogTail + "\nEND TAIL");
+        t.printStackTrace();
+        fail("Checking system.log for audit log errors failed");
+      }
+      // ensure the system.log does not have "Failed notifying listeners"
+      if (systemLogTail.contains("Failed notifying listeners")) {
+        // dump the system.log tail
+        System.err.println("Tail of system.log\n" + systemLogTail + "\nEND TAIL");
+        fail("Audit logs generated an unexpected exception");
+      }
+    } finally {
+      // Stop already called after each test ends
+    }
+  }
+}

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/DockerImageIT.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/DockerImageIT.java
@@ -34,7 +34,6 @@ public class DockerImageIT extends BaseDockerIntegrationTest {
     try {
       docker.runCommand("which", "curl");
     } catch (Throwable t) {
-      // this is expected, ensure the message indicates a process error code
       fail(
           "\"curl\" was not found in the image. Please ensure it has been added to the Dockerfile");
     }

--- a/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
+++ b/management-api-test/src/test/java/com/datastax/mgmtapi/helpers/DockerHelper.java
@@ -142,6 +142,40 @@ public class DockerHelper {
     }
   }
 
+  public String runCommandWithOutput(String... commandAndArgs)
+      throws IOException, InterruptedException {
+    if (container == null) throw new IllegalStateException("Container not started");
+    // prefix the command arguments with "docker exec mgmtapi"
+    final ProcessBuilder pb = new ProcessBuilder("docker", "exec", CONTAINER_NAME);
+    pb.command().addAll(Arrays.asList(commandAndArgs));
+    final Process process = pb.start();
+    final int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      logger.error("Command had a non-zero exit code: " + exitCode);
+      new BufferedReader(new InputStreamReader(process.getInputStream()))
+          .lines()
+          .forEach(
+              line -> {
+                logger.error("Command output stream: " + line);
+              });
+      new BufferedReader(new InputStreamReader(process.getErrorStream()))
+          .lines()
+          .forEach(
+              line -> {
+                logger.error("Command error stream: " + line);
+              });
+      throw new IOException("Command was not successful: " + Arrays.toString(commandAndArgs));
+    }
+    StringBuilder strBuilder = new StringBuilder();
+    new BufferedReader(new InputStreamReader(process.getInputStream()))
+        .lines()
+        .forEach(
+            line -> {
+              strBuilder.append(line).append("\n");
+            });
+    return strBuilder.toString();
+  }
+
   public void tailSystemLog(int numberOfLines) {
     if (container == null) throw new IllegalStateException("Container not started");
 

--- a/management-api-test/src/test/resources/com/datastax/mgmtapi/audit-log-test.yaml
+++ b/management-api-test/src/test/resources/com/datastax/mgmtapi/audit-log-test.yaml
@@ -1,0 +1,66 @@
+apiVersion: datastax.com/v1alpha1
+kind: DseDatacenter
+metadata:
+  name: dc1
+spec:
+  clusterName: testcluster
+  size: 3
+  resources:
+    requests:
+      # TODO this should be a template var and dependent
+      # on the t-shirt size of the cluster
+      memory: 1000
+      cpu: 1000
+  storageClaim:
+    storageclassname: idk
+    resources:
+      requests:
+        storage: idk
+  racks:
+    - name: rack0
+      zone: idk
+  allowMultipleNodesPerWorker: false
+  serviceAccount: "dse"
+  parked: false
+  canaryUpgrade: false
+  configBuilderImage: idk
+  dseVersion: "6.8.0"
+  dseImage: idk
+  dseSuperuserSecret: dse-credentials
+  managementApiAuth:
+    # insecure: {}
+    manual:
+      clientSecretName: mgmt-api-client-credentials
+      serverSecretName: mgmt-api-server-credentials
+  config:
+    node-topology:
+      dc: dc1
+      rack: rack1
+    prometheus:
+      enabled: true
+      port: 9103
+      staleness-delta: 300
+    cassandra-yaml:
+      authenticator: org.apache.cassandra.auth.PasswordAuthenticator
+      authorizer: org.apache.cassandra.auth.CassandraAuthorizer
+      auto_snapshot: false # default is true, but we don't have a good way to use or clean up snapshots when someone drops a table
+      #compaction_throughput_mb_per_sec: 64 # default is 16
+      concurrent_compactors: 2 # this is based on tuning for four cores / 15 GB
+      file_cache_size_in_mb: 500 # this is based on tuning for four cores / 15 GB
+      #hinted_handoff_throttle_in_kb: 512 # this is based on tuning for four cores / 15 GB
+      memtable_flush_writers: 2  # this is based on tuning for four cores / 15 GB
+      num_tokens: 256 # default is 1
+      phi_convict_threshold: 12 # default is 8
+      role_manager: org.apache.cassandra.auth.CassandraRoleManager
+      endpoint_snitch:  org.apache.cassandra.locator.GossipingPropertyFileSnitch
+      audit_logging_options:
+        enabled: true
+        logger:
+          - class_name: BinAuditLogger
+    jvm-server-options:
+      heap_new_size: 100M
+      max_heap_size: 500M
+      additional-jvm-opts:
+        - "-Dcassandra.skip_default_role_setup=true"
+        - "-Dcassandra.superuser_setup_delay_ms=100"
+        - "-Dcassandra.system_distributed_replication=dc1:1"


### PR DESCRIPTION
This patch updates the Management API RpcStatement class so that it provides a "dummy" AuditLogContext that will prevent exceptions when Audit Logging is enabled. The solution relies on the fact that "system" logs are excluded from the default Audit Log configuration. The implementation in this patch uses "system" as the keyspace for all AuditLogContexts for any operations executed via the Management API RpcStatement.

Fixes #309