### PR TITLE
Fix metric registry issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for Management API, new PRs should update the `main / unreleased` sect
 ## unreleased
 * [BUGFIX] [#770](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/770) Use Public Datastax repos
 * [BUGFIX] [#309](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/309) Set default AuditLogContext for the RpcStatements that is by default hidden
+* [BUGFIX] [#774](https://github.com/k8ssandra/management-api-for-apache-cassandra/issues/774) When table (or other similar metric batch) is removed, correctly clean the cached metrics references in case the metrics get recreated with same name.
 
 ## v0.1.122 [2026-07-03]
 * [CHANGE] Rename the dse images from dse-mgmtapi-6_8 to dse-mgmtapi

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
@@ -94,26 +94,20 @@ public class CassandraMetricDefinition
 
   @Override
   public int hashCode() {
-    return Objects.hash(labelNames, labelValues, metricName);
+    return Objects.hash(labelNames, labelValues, metricName, dropWizardName);
   }
 
   @Override
   public String toString() {
-    return "CassandraMetricDefinition{"
-        + "labelNames="
-        + labelNames
-        + ", labelValues="
-        + labelValues
-        + ", metricName='"
-        + metricName
-        + '\''
-        + ", valueGetter="
-        + valueGetter
-        + ", keep="
-        + keep
-        + ", filler="
-        + filler
-        + '}';
+    return "CassandraMetricDefinition{" +
+        "labelNames=" + labelNames +
+        ", labelValues=" + labelValues +
+        ", metricName='" + metricName + '\'' +
+        ", dropWizardName='" + dropWizardName + '\'' +
+        ", valueGetter=" + valueGetter +
+        ", keep=" + keep +
+        ", filler=" + filler +
+        '}';
   }
 
   @Override

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
@@ -99,15 +99,24 @@ public class CassandraMetricDefinition
 
   @Override
   public String toString() {
-    return "CassandraMetricDefinition{" +
-        "labelNames=" + labelNames +
-        ", labelValues=" + labelValues +
-        ", metricName='" + metricName + '\'' +
-        ", dropWizardName='" + dropWizardName + '\'' +
-        ", valueGetter=" + valueGetter +
-        ", keep=" + keep +
-        ", filler=" + filler +
-        '}';
+    return "CassandraMetricDefinition{"
+        + "labelNames="
+        + labelNames
+        + ", labelValues="
+        + labelValues
+        + ", metricName='"
+        + metricName
+        + '\''
+        + ", dropWizardName='"
+        + dropWizardName
+        + '\''
+        + ", valueGetter="
+        + valueGetter
+        + ", keep="
+        + keep
+        + ", filler="
+        + filler
+        + '}';
   }
 
   @Override

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricDefinition.java
@@ -18,6 +18,7 @@ public class CassandraMetricDefinition
   private final List<String> labelNames;
   private final List<String> labelValues;
   private String metricName;
+  private String dropWizardName;
   private Supplier<Double> valueGetter;
 
   private boolean keep = true;
@@ -25,10 +26,11 @@ public class CassandraMetricDefinition
   private Consumer<List<Collector.MetricFamilySamples.Sample>> filler;
 
   public CassandraMetricDefinition(
-      String metricName, List<String> labelNames, List<String> labelValues) {
+      String metricName, String dropWizardName, List<String> labelNames, List<String> labelValues) {
     this.labelNames = labelNames;
     this.labelValues = labelValues;
     this.metricName = metricName;
+    this.dropWizardName = dropWizardName;
   }
 
   public List<String> getLabelNames() {
@@ -41,6 +43,10 @@ public class CassandraMetricDefinition
 
   public String getMetricName() {
     return metricName;
+  }
+
+  public String getDropWizardName() {
+    return dropWizardName;
   }
 
   void setValueGetter(Supplier<Double> valueGetter) {
@@ -82,7 +88,8 @@ public class CassandraMetricDefinition
     return keep == that.keep
         && Objects.equals(labelNames, that.labelNames)
         && Objects.equals(labelValues, that.labelValues)
-        && Objects.equals(metricName, that.metricName);
+        && Objects.equals(metricName, that.metricName)
+        && Objects.equals(dropWizardName, that.dropWizardName);
   }
 
   @Override
@@ -112,6 +119,11 @@ public class CassandraMetricDefinition
   @Override
   public int compareTo(CassandraMetricDefinition o) {
     int compareValue = metricName.compareTo(o.metricName);
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    compareValue = dropWizardName.compareTo(o.dropWizardName);
     if (compareValue != 0) {
       return compareValue;
     }

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricNameParser.java
@@ -79,7 +79,7 @@ public class CassandraMetricNameParser {
         removeDoubleUnderscore(Collector.sanitizeMetricName(this.clean(dropwizardName)));
 
     CassandraMetricDefinition metricDef =
-        new CassandraMetricDefinition(metricName, labelNames, labelValues);
+        new CassandraMetricDefinition(metricName, dropwizardName, labelNames, labelValues);
 
     // Process replace rules here
     replace(dropwizardName, metricDef);

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
@@ -102,14 +102,15 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
     // Filter unwanted definitions
     prototype.getDefinitions().removeIf(next -> !next.isKeep());
 
-    if (prototype.getDefinitions().size() < 1) {
+    if (prototype.getDefinitions().isEmpty()) {
       return;
     }
+
+    cache.put(dropwizardName, metricName);
 
     RefreshableMetricFamilySamples familySamples;
     if (!familyCache.containsKey(metricName)) {
       familyCache.put(metricName, prototype);
-      cache.put(dropwizardName, metricName);
     } else {
       familySamples = familyCache.get(metricName);
       prototype.getDefinitions().forEach(familySamples::addDefinition);
@@ -128,14 +129,15 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
         .getDefinitions()
         .removeIf(
             cmd ->
-                cmd.getMetricName().equals(metricName)
+                (cmd.getMetricName().equals(metricName)
                     || cmd.getMetricName().equals(metricName + "_count")
-                    || cmd.getMetricName().equals(metricName + "_total"));
+                    || cmd.getMetricName().equals(metricName + "_total"))
+        && cmd.getDropWizardName().equals(dropwizardName));
 
     if (familySampler.getDefinitions().isEmpty()) {
       this.familyCache.remove(metricName);
-      cache.remove(dropwizardName);
     }
+    cache.remove(dropwizardName);
   }
 
   private void setGaugeHistogramFiller(Gauge gauge, CassandraMetricDefinition proto) {

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
@@ -108,13 +108,15 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
 
     cache.put(dropwizardName, metricName);
 
-    RefreshableMetricFamilySamples familySamples;
-    if (!familyCache.containsKey(metricName)) {
-      familyCache.put(metricName, prototype);
-    } else {
-      familySamples = familyCache.get(metricName);
-      prototype.getDefinitions().forEach(familySamples::addDefinition);
-    }
+    familyCache.compute(
+        metricName,
+        (name, familySamples) -> {
+          if (familySamples == null) {
+            return prototype;
+          }
+          prototype.getDefinitions().forEach(familySamples::addDefinition);
+          return familySamples;
+        });
   }
 
   public void removeFromCache(String dropwizardName) {

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListener.java
@@ -132,9 +132,9 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
         .removeIf(
             cmd ->
                 (cmd.getMetricName().equals(metricName)
-                    || cmd.getMetricName().equals(metricName + "_count")
-                    || cmd.getMetricName().equals(metricName + "_total"))
-        && cmd.getDropWizardName().equals(dropwizardName));
+                        || cmd.getMetricName().equals(metricName + "_count")
+                        || cmd.getMetricName().equals(metricName + "_total"))
+                    && cmd.getDropWizardName().equals(dropwizardName));
 
     if (familySampler.getDefinitions().isEmpty()) {
       this.familyCache.remove(metricName);
@@ -422,25 +422,26 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
           long cumulativeCount = 0;
           for (int i = 0; i < buckets.length; i++) {
             int offsetFix = microLatencyBuckets ? 1 : 1000;
-            if (outputIndex < LATENCY_OFFSETS.length
+            while (outputIndex < LATENCY_OFFSETS.length
                 && buckets[i] > (LATENCY_OFFSETS[outputIndex] * offsetFix)) {
               List<String> labelValues = new ArrayList<>(bucket.getLabelValues().size() + 1);
               int j = 0;
               for (; j < bucket.getLabelValues().size(); j++) {
                 labelValues.add(j, bucket.getLabelValues().get(j));
               }
-              labelValues.add(j, LATENCY_OFFSETS_TEXT[outputIndex++]);
+              labelValues.add(j, LATENCY_OFFSETS_TEXT[outputIndex]);
               Collector.MetricFamilySamples.Sample sample =
                   new Collector.MetricFamilySamples.Sample(
                       bucket.getMetricName(), bucket.getLabelNames(), labelValues, cumulativeCount);
               samples.add(sample);
+              outputIndex++;
             }
 
             cumulativeCount += values[i];
           }
 
           // Add any remaining buckets that didn't have any values
-          while (outputIndex++ < LATENCY_OFFSETS.length) {
+          while (outputIndex < LATENCY_OFFSETS.length) {
             List<String> labelValues = new ArrayList<>(bucket.getLabelValues().size() + 1);
             int j = 0;
             for (; j < bucket.getLabelValues().size(); j++) {
@@ -451,6 +452,7 @@ public class CassandraMetricRegistryListener implements MetricRegistryListener {
                 new Collector.MetricFamilySamples.Sample(
                     bucket.getMetricName(), bucket.getLabelNames(), labelValues, cumulativeCount);
             samples.add(sample);
+            outputIndex++;
           }
 
           // Last bucket must be +Inf and same as _count

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package io.k8ssandra.metrics.builder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import io.k8ssandra.metrics.builder.relabel.RelabelSpec;
+import io.k8ssandra.metrics.config.Configuration;
+import io.k8ssandra.metrics.prometheus.CassandraDropwizardExports;
+import io.prometheus.client.Collector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class CassandraMetricRegistryListenerTest {
+
+  private static final String PROMETHEUS_METRIC_NAME =
+      "org_apache_cassandra_metrics_table_metric_name";
+  private static final String KEYSPACE_NAME = "KeyspaceName";
+  private static final String TABLE_NAME = "TableName";
+  private static final String SIBLING_TABLE_NAME = "SiblingTable";
+
+  @Test
+  public void concurrentlyRegistersTableMetricsInSameFamily() throws Exception {
+    CyclicBarrier containsKeyBarrier = new CyclicBarrier(2);
+    ConcurrentHashMap<String, RefreshableMetricFamilySamples> familyCache =
+        new ConcurrentHashMap<String, RefreshableMetricFamilySamples>() {
+          @Override
+          public boolean containsKey(Object key) {
+            boolean containsKey = super.containsKey(key);
+            if (PROMETHEUS_METRIC_NAME.equals(key)) {
+              try {
+                // Make both registrations observe the family as absent before either can put it.
+                containsKeyBarrier.await(5, TimeUnit.SECONDS);
+              } catch (Exception e) {
+                throw new AssertionError("Registrations did not reach containsKey together", e);
+              }
+            }
+            return containsKey;
+          }
+        };
+    CassandraMetricRegistryListener listener =
+        new CassandraMetricRegistryListener(familyCache, tableMetricConfiguration());
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<?> first =
+          executor.submit(
+              () -> listener.onCounterAdded(tableMetricName(TABLE_NAME), new Counter()));
+      Future<?> second =
+          executor.submit(
+              () -> listener.onCounterAdded(tableMetricName(SIBLING_TABLE_NAME), new Counter()));
+
+      first.get(5, TimeUnit.SECONDS);
+      second.get(5, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    RefreshableMetricFamilySamples family = familyCache.get(PROMETHEUS_METRIC_NAME);
+    assertNotNull("Shared table metric family should be registered", family);
+    assertEquals(
+        "Both table definitions should be retained", 2, family.getDefinitions().size());
+  }
+
+  @Test
+  public void removesTableMetricMergedIntoExistingFamily() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    CassandraDropwizardExports exporter =
+        new CassandraDropwizardExports(registry, tableMetricConfiguration());
+
+    Counter sibling = registry.counter(tableMetricName(SIBLING_TABLE_NAME));
+    sibling.inc(10);
+    Counter target = registry.counter(tableMetricName(TABLE_NAME));
+    target.inc();
+
+    registry.remove(tableMetricName(TABLE_NAME));
+
+    List<Collector.MetricFamilySamples> samples = exporter.collect();
+    assertNull(
+        "Removed table metric should no longer be exported",
+        findTableSample(samples, KEYSPACE_NAME, TABLE_NAME));
+    assertSampleValue(samples, SIBLING_TABLE_NAME, 10.0);
+  }
+
+  @Test
+  public void removingFirstTableMetricKeepsSiblingInSameFamily() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    CassandraDropwizardExports exporter =
+        new CassandraDropwizardExports(registry, tableMetricConfiguration());
+
+    Counter target = registry.counter(tableMetricName(TABLE_NAME));
+    target.inc();
+    Counter sibling = registry.counter(tableMetricName(SIBLING_TABLE_NAME));
+    sibling.inc(10);
+
+    registry.remove(tableMetricName(TABLE_NAME));
+
+    List<Collector.MetricFamilySamples> samples = exporter.collect();
+    assertNull(
+        "Removed table metric should no longer be exported",
+        findTableSample(samples, KEYSPACE_NAME, TABLE_NAME));
+    assertSampleValue(samples, SIBLING_TABLE_NAME, 10.0);
+  }
+
+  @Test
+  public void reRegistersRemovedTableMetric() throws Exception {
+    MetricRegistry registry = new MetricRegistry();
+    CassandraDropwizardExports exporter =
+        new CassandraDropwizardExports(registry, tableMetricConfiguration());
+
+    // Register a sibling first so both Dropwizard metrics are merged into the same Prometheus
+    // family. The target metric therefore exercises updateCache's existing-family branch.
+    Counter sibling = registry.counter(tableMetricName(SIBLING_TABLE_NAME));
+    sibling.inc(10);
+
+    String dropwizardName = tableMetricName(TABLE_NAME);
+    Counter original = registry.counter(dropwizardName);
+    original.inc();
+
+    registry.remove(dropwizardName);
+
+    Counter replacement = registry.counter(dropwizardName);
+    replacement.inc(2);
+
+    List<Collector.MetricFamilySamples> samples = exporter.collect();
+    Collector.MetricFamilySamples.Sample sample =
+        findTableSample(samples, KEYSPACE_NAME, TABLE_NAME);
+
+    assertNotNull("Re-registered table metric should still be exported", sample);
+    assertEquals("Sample should use the re-registered metric", 2.0, sample.value, 0.0);
+    assertSampleValue(samples, SIBLING_TABLE_NAME, 10.0);
+  }
+
+  private String tableMetricName(String tableName) {
+    return String.format(
+        "org.apache.cassandra.metrics.Table.MetricName.%s.%s", KEYSPACE_NAME, tableName);
+  }
+
+  private Configuration tableMetricConfiguration() {
+    String tableMetricPattern =
+        "org\\.apache\\.cassandra\\.metrics\\.Table\\.(\\w+)\\.(\\w+)\\.(\\w+)";
+    List<String> originalName = Collections.singletonList("__origname__");
+
+    Configuration config = new Configuration();
+    config.setRelabels(
+        Arrays.asList(
+            new RelabelSpec(originalName, "", tableMetricPattern, "", "keyspace", "$2"),
+            new RelabelSpec(originalName, "", tableMetricPattern, "", "table", "$3"),
+            new RelabelSpec(
+                originalName,
+                "",
+                tableMetricPattern,
+                "",
+                "__name__",
+                "org_apache_cassandra_metrics_table_$1")));
+    return config;
+  }
+
+  private Collector.MetricFamilySamples.Sample findTableSample(
+      List<Collector.MetricFamilySamples> families, String keyspaceName, String tableName) {
+    for (Collector.MetricFamilySamples family : families) {
+      for (Collector.MetricFamilySamples.Sample sample : family.samples) {
+        if (PROMETHEUS_METRIC_NAME.equals(sample.name)
+            && keyspaceName.equals(labelValue(sample, "keyspace"))
+            && tableName.equals(labelValue(sample, "table"))) {
+          return sample;
+        }
+      }
+    }
+    return null;
+  }
+
+  private void assertSampleValue(
+      List<Collector.MetricFamilySamples> samples, String tableName, double expectedValue) {
+    Collector.MetricFamilySamples.Sample sample =
+        findTableSample(samples, KEYSPACE_NAME, tableName);
+    assertNotNull(tableName + " metric should be exported", sample);
+    assertEquals(expectedValue, sample.value, 0.0);
+  }
+
+  private String labelValue(Collector.MetricFamilySamples.Sample sample, String labelName) {
+    int index = sample.labelNames.indexOf(labelName);
+    return index < 0 ? null : sample.labelValues.get(index);
+  }
+}

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
@@ -5,19 +5,29 @@
  */
 package io.k8ssandra.metrics.builder;
 
+import static io.k8ssandra.metrics.builder.CassandraMetricsTools.INF_BUCKET;
+import static io.k8ssandra.metrics.builder.CassandraMetricsTools.LATENCY_OFFSETS;
+import static io.k8ssandra.metrics.builder.CassandraMetricsTools.LATENCY_OFFSETS_TEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import io.k8ssandra.metrics.builder.relabel.RelabelSpec;
 import io.k8ssandra.metrics.config.Configuration;
 import io.k8ssandra.metrics.prometheus.CassandraDropwizardExports;
 import io.prometheus.client.Collector;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -33,6 +43,50 @@ public class CassandraMetricRegistryListenerTest {
   private static final String KEYSPACE_NAME = "KeyspaceName";
   private static final String TABLE_NAME = "TableName";
   private static final String SIBLING_TABLE_NAME = "SiblingTable";
+
+  @Test
+  public void exportsEveryConfiguredTimerBucket() throws Exception {
+    ConcurrentHashMap<String, RefreshableMetricFamilySamples> familyCache =
+        new ConcurrentHashMap<>();
+    CassandraMetricRegistryListener listener =
+        new CassandraMetricRegistryListener(familyCache, new Configuration());
+    int offsetFactor = latencyOffsetFactor(listener);
+    listener.onTimerAdded(
+        "test.timer",
+        new FixedSnapshotTimer(
+            new DecayingEstimatedHistogramSnapshot(
+                scaledOffsets(
+                    offsetFactor, 40, 70, 200, 600, 2_000, 10_000, 100_000, 1_000_000),
+                new long[] {2, 3, 5, 7, 11, 13, 17, 19})));
+
+    RefreshableMetricFamilySamples family = familyCache.get("test_timer");
+    assertNotNull("Timer metric family should be registered", family);
+    family.refreshSamples();
+
+    Map<String, Double> buckets = new HashMap<>();
+    for (Collector.MetricFamilySamples.Sample sample : family.samples) {
+      if ("test_timer_bucket".equals(sample.name)) {
+        buckets.put(sample.labelValues.get(sample.labelValues.size() - 1), sample.value);
+      }
+    }
+
+    assertEquals(LATENCY_OFFSETS.length + 1, buckets.size());
+    for (String offset : LATENCY_OFFSETS_TEXT) {
+      assertTrue("Missing timer bucket " + offset, buckets.containsKey(offset));
+    }
+    assertTrue("Missing +Inf timer bucket", buckets.containsKey(INF_BUCKET));
+
+    assertBucketValue(buckets, "35", 0);
+    assertBucketValue(buckets, "60", 2);
+    assertBucketValue(buckets, "103", 5);
+    assertBucketValue(buckets, "310", 10);
+    assertBucketValue(buckets, "924", 17);
+    assertBucketValue(buckets, "2759", 28);
+    assertBucketValue(buckets, "14237", 41);
+    assertBucketValue(buckets, "126934", 58);
+    assertBucketValue(buckets, "1131752", 77);
+    assertBucketValue(buckets, INF_BUCKET, 77);
+  }
 
   @Test
   public void concurrentlyRegistersTableMetricsInSameFamily() throws Exception {
@@ -73,8 +127,7 @@ public class CassandraMetricRegistryListenerTest {
 
     RefreshableMetricFamilySamples family = familyCache.get(PROMETHEUS_METRIC_NAME);
     assertNotNull("Shared table metric family should be registered", family);
-    assertEquals(
-        "Both table definitions should be retained", 2, family.getDefinitions().size());
+    assertEquals("Both table definitions should be retained", 2, family.getDefinitions().size());
   }
 
   @Test
@@ -196,5 +249,93 @@ public class CassandraMetricRegistryListenerTest {
   private String labelValue(Collector.MetricFamilySamples.Sample sample, String labelName) {
     int index = sample.labelNames.indexOf(labelName);
     return index < 0 ? null : sample.labelValues.get(index);
+  }
+
+  private void assertBucketValue(
+      Map<String, Double> buckets, String upperBound, double expectedValue) {
+    assertEquals(
+        "Unexpected value for timer bucket " + upperBound,
+        expectedValue,
+        buckets.get(upperBound),
+        0.0);
+  }
+
+  private int latencyOffsetFactor(CassandraMetricRegistryListener listener) throws Exception {
+    Field field = CassandraMetricRegistryListener.class.getDeclaredField("microLatencyBuckets");
+    field.setAccessible(true);
+    return field.getBoolean(listener) ? 1 : 1000;
+  }
+
+  private long[] scaledOffsets(int factor, long... offsets) {
+    long[] scaled = new long[offsets.length];
+    for (int i = 0; i < offsets.length; i++) {
+      scaled[i] = offsets[i] * factor;
+    }
+    return scaled;
+  }
+
+  private static class FixedSnapshotTimer extends Timer {
+    private final Snapshot snapshot;
+
+    private FixedSnapshotTimer(Snapshot snapshot) {
+      this.snapshot = snapshot;
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+      return snapshot;
+    }
+  }
+
+  public static class DecayingEstimatedHistogramSnapshot extends Snapshot {
+    private final long[] offsets;
+    private final long[] values;
+
+    public DecayingEstimatedHistogramSnapshot(long[] offsets, long[] values) {
+      this.offsets = offsets;
+      this.values = values;
+    }
+
+    public long[] getOffsets() {
+      return offsets;
+    }
+
+    @Override
+    public double getValue(double quantile) {
+      return 0;
+    }
+
+    @Override
+    public long[] getValues() {
+      return values;
+    }
+
+    @Override
+    public int size() {
+      return values.length;
+    }
+
+    @Override
+    public long getMax() {
+      return 0;
+    }
+
+    @Override
+    public double getMean() {
+      return 0;
+    }
+
+    @Override
+    public long getMin() {
+      return 0;
+    }
+
+    @Override
+    public double getStdDev() {
+      return 0;
+    }
+
+    @Override
+    public void dump(OutputStream output) {}
   }
 }

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/CassandraMetricRegistryListenerTest.java
@@ -55,8 +55,7 @@ public class CassandraMetricRegistryListenerTest {
         "test.timer",
         new FixedSnapshotTimer(
             new DecayingEstimatedHistogramSnapshot(
-                scaledOffsets(
-                    offsetFactor, 40, 70, 200, 600, 2_000, 10_000, 100_000, 1_000_000),
+                scaledOffsets(offsetFactor, 40, 70, 200, 600, 2_000, 10_000, 100_000, 1_000_000),
                 new long[] {2, 3, 5, 7, 11, 13, 17, 19})));
 
     RefreshableMetricFamilySamples family = familyCache.get("test_timer");

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
@@ -45,6 +45,7 @@ public class MultiFilterTest {
     CassandraMetricDefinition tableDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.cassandra.metrics.Table.RangeLatency.system.peers_v2",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -57,13 +58,16 @@ public class MultiFilterTest {
     CassandraMetricDefinition keyspaceDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.cassandra.metrics.Keyspace.RangeLatency.system",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "Test Cluster", "dc1", "rack1", "system"));
 
     CassandraMetricDefinition jvmDefinition =
         new CassandraMetricDefinition(
-            "jvm_classes_loaded_total", Lists.newArrayList(), Lists.newArrayList());
+            "jvm_classes_loaded_total",
+            "jvm.classes.loaded.total",
+            Lists.newArrayList(), Lists.newArrayList());
 
     List<CassandraMetricDefinition> definitions =
         Lists.newArrayList(tableDefinition, keyspaceDefinition, jvmDefinition);
@@ -98,6 +102,7 @@ public class MultiFilterTest {
     CassandraMetricDefinition tableDefinitionTest =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.Cassandra.Metrics.RangeLatencyCount.system.peers_v2",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -110,6 +115,7 @@ public class MultiFilterTest {
     CassandraMetricDefinition tableDefinitionProd =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.Cassandra.Metrics.RangeLatencyCount.system.system_schema",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -122,6 +128,7 @@ public class MultiFilterTest {
     CassandraMetricDefinition keyspaceDefinitionProd =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.Cassandra.Metrics.RangeLatencyCount.system",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "production", "dc1", "rack1", "system"));
@@ -129,6 +136,7 @@ public class MultiFilterTest {
     CassandraMetricDefinition keyspaceDefinitionTest =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.Cassandra.Metrics.RangeLatencyCount.system",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "Test Cluster", "dc1", "rack1", "system"));

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/MultiFilterTest.java
@@ -67,7 +67,8 @@ public class MultiFilterTest {
         new CassandraMetricDefinition(
             "jvm_classes_loaded_total",
             "jvm.classes.loaded.total",
-            Lists.newArrayList(), Lists.newArrayList());
+            Lists.newArrayList(),
+            Lists.newArrayList());
 
     List<CassandraMetricDefinition> definitions =
         Lists.newArrayList(tableDefinition, keyspaceDefinition, jvmDefinition);

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/SingleFilterTests.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/SingleFilterTests.java
@@ -198,7 +198,10 @@ public class SingleFilterTests {
 
     CassandraMetricDefinition hasTableLabel =
         new CassandraMetricDefinition(
-            "has_table_label", "HasTableLabel", Lists.newArrayList("table"), Lists.newArrayList("value"));
+            "has_table_label",
+            "HasTableLabel",
+            Lists.newArrayList("table"),
+            Lists.newArrayList("value"));
     parser.replace("", hasTableLabel);
     assertFalse(hasTableLabel.isKeep());
 
@@ -210,7 +213,10 @@ public class SingleFilterTests {
 
     CassandraMetricDefinition hasOtherLabels =
         new CassandraMetricDefinition(
-            "has_table_label", "Has.Table.Label", Lists.newArrayList("keyspace"), Lists.newArrayList("value"));
+            "has_table_label",
+            "Has.Table.Label",
+            Lists.newArrayList("keyspace"),
+            Lists.newArrayList("value"));
     parser.replace("", hasOtherLabels);
     assertTrue(hasOtherLabels.isKeep());
   }

--- a/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/SingleFilterTests.java
+++ b/management-api-agent-common/src/test/java/io/k8ssandra/metrics/builder/relabel/SingleFilterTests.java
@@ -37,6 +37,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition tableDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.cassandra.metrics.Table.RangeLatency.system.peers_v2",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -52,6 +53,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition keyspaceDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.cassandra.metrics.Keyspace.RangeLatencyCount.system",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "Test Cluster", "dc1", "rack1", "system"));
@@ -82,6 +84,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition tableDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.cassandra.metrics.Table.RangeLatency.system.peers_v2",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -96,6 +99,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition tableDefinitionKeep =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_estimated_partition_size_histogram",
+            "org.apache.Cassandra.Metrics.TableEstimatedPartitionSize.system.dropped_columns",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -110,6 +114,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition keyspaceDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.cassandra.metrics.Keyspace.RangeLatencyCount.system.peers",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "Test Cluster", "dc1", "rack1", "system"));
@@ -143,6 +148,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition tableDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_range_latency_count",
+            "org.apache.cassandra.metrics.Table.RangeLatencyCount.system.peers_v2",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -157,6 +163,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition tableDefinitionKeep =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_table_estimated_partition_size_histogram",
+            "org.apache.cassandra.metrics.Table.EstimatedPartitionSize.system.dropped_columns",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace", "table"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3",
@@ -171,6 +178,7 @@ public class SingleFilterTests {
     CassandraMetricDefinition keyspaceDefinition =
         new CassandraMetricDefinition(
             "org_apache_cassandra_metrics_keyspace_range_latency_count",
+            "org.apache.cassandra.metrics.Keyspace.RangeLatencyCount.system",
             Lists.newArrayList("host", "cluster", "datacenter", "rack", "keyspace"),
             Lists.newArrayList(
                 "6cc2e5ce-e73f-4592-8d02-fd5e17a070e3", "Test Cluster", "dc1", "rack1", "system"));
@@ -190,19 +198,19 @@ public class SingleFilterTests {
 
     CassandraMetricDefinition hasTableLabel =
         new CassandraMetricDefinition(
-            "has_table_label", Lists.newArrayList("table"), Lists.newArrayList("value"));
+            "has_table_label", "HasTableLabel", Lists.newArrayList("table"), Lists.newArrayList("value"));
     parser.replace("", hasTableLabel);
     assertFalse(hasTableLabel.isKeep());
 
     CassandraMetricDefinition hasNoLabels =
         new CassandraMetricDefinition(
-            "has_table_label", Lists.newArrayList(), Lists.newArrayList());
+            "has_table_label", "HasTableLabel", Lists.newArrayList(), Lists.newArrayList());
     parser.replace("", hasNoLabels);
     assertTrue(hasNoLabels.isKeep());
 
     CassandraMetricDefinition hasOtherLabels =
         new CassandraMetricDefinition(
-            "has_table_label", Lists.newArrayList("keyspace"), Lists.newArrayList("value"));
+            "has_table_label", "Has.Table.Label", Lists.newArrayList("keyspace"), Lists.newArrayList("value"));
     parser.replace("", hasOtherLabels);
     assertTrue(hasOtherLabels.isKeep());
   }


### PR DESCRIPTION
This PR can be reviewed per commit, each commit is a complete feature (other than tests being added in the commit 3 for the first 2 commits).

Fixes several issues in the metrics library related to registering and removing the metrics as well as one bucket bug which has actually been in the MCAC already (as that calculation was lifted from there).

Fixes #774 