### PR TITLE
430: Uniform support for epoll/kqueue

### DIFF
--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
@@ -8,12 +8,11 @@ package com.datastax.mgmtapi.interceptors;
 import com.datastax.mgmtapi.NodeOpsProvider;
 import com.datastax.mgmtapi.ShimLoader;
 import com.datastax.mgmtapi.ipc.IPCController;
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import com.google.common.collect.ImmutableMap;
 import io.k8ssandra.metrics.interceptors.MetricsInterceptor;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.nio.file.Paths;
@@ -58,11 +57,17 @@ public class CassandraDaemonInterceptor {
 
       NodeOpsProvider.instance.get().register();
 
-      if (!Epoll.isAvailable()) throw new RuntimeException("Event loop needed");
+      if (!NativeTransport.isNativeTransportAvailable()) {
+        logger.warn(
+            "Native transport (epoll/kqueue) is not available. The Management API IPC server "
+                + "over Unix domain socket cannot start. This is only acceptable in "
+                + "development, testing, or lab environments.");
+        return;
+      }
 
       File unixSock = Paths.get(socketFileStr).toFile();
 
-      final EventLoopGroup group = new EpollEventLoopGroup(8);
+      final EventLoopGroup group = NativeTransport.nativeEventLoopGroup(8);
       final Server.ConnectionTracker connectionTracker = getTracker();
 
       IPCController controller =

--- a/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
+++ b/management-api-agent-common/src/main/java/com/datastax/mgmtapi/interceptors/CassandraDaemonInterceptor.java
@@ -58,11 +58,7 @@ public class CassandraDaemonInterceptor {
       NodeOpsProvider.instance.get().register();
 
       if (!NativeTransport.isNativeTransportAvailable()) {
-        logger.warn(
-            "Native transport (epoll/kqueue) is not available. The Management API IPC server "
-                + "over Unix domain socket cannot start. This is only acceptable in "
-                + "development, testing, or lab environments.");
-        return;
+        throw new RuntimeException("Event loop needed");
       }
 
       File unixSock = Paths.get(socketFileStr).toFile();

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/http/NettyMetricsHttpServer.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/http/NettyMetricsHttpServer.java
@@ -5,13 +5,13 @@
  */
 package io.k8ssandra.metrics.http;
 
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import io.k8ssandra.metrics.config.Configuration;
 import io.k8ssandra.metrics.config.EndpointConfiguration;
 import io.k8ssandra.metrics.config.TLSConfiguration;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -42,7 +42,7 @@ public class NettyMetricsHttpServer {
     ServerBootstrap channel =
         b.group(group)
             .childHandler(new NettyHttpInitializer(sslCtx))
-            .channel(EpollServerSocketChannel.class);
+            .channel(NativeTransport.tcpServerSocketChannelClass());
 
     int port = DEFAULT_METRICS_PORT;
     String host = null;

--- a/management-api-agent-common/src/main/java/io/k8ssandra/metrics/interceptors/MetricsInterceptor.java
+++ b/management-api-agent-common/src/main/java/io/k8ssandra/metrics/interceptors/MetricsInterceptor.java
@@ -5,6 +5,7 @@
  */
 package io.k8ssandra.metrics.interceptors;
 
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import io.k8ssandra.metrics.config.ConfigReader;
 import io.k8ssandra.metrics.config.Configuration;
 import io.k8ssandra.metrics.http.NettyMetricsHttpServer;
@@ -12,7 +13,6 @@ import io.k8ssandra.metrics.prometheus.CassandraDropwizardExports;
 import io.k8ssandra.metrics.prometheus.CassandraTasksExports;
 import io.k8ssandra.metrics.prometheus.JvmExports;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import java.util.concurrent.Callable;
 import net.bytebuddy.agent.builder.AgentBuilder.Transformer;
 import net.bytebuddy.description.type.TypeDescription;
@@ -79,7 +79,7 @@ public class MetricsInterceptor {
       }
 
       // Create /metrics handler. Note, this doesn't support larger than nThreads=1
-      final EventLoopGroup httpGroup = new EpollEventLoopGroup(1);
+      final EventLoopGroup httpGroup = NativeTransport.tcpEventLoopGroup(1);
 
       // Share them from HTTP server
       NettyMetricsHttpServer server = new NettyMetricsHttpServer(config);

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/IPCController.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/IPCController.java
@@ -12,13 +12,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerDomainSocketChannel;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueDomainSocketChannel;
-import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.File;
 import java.net.SocketAddress;
@@ -55,10 +48,6 @@ public class IPCController {
       Map<ChannelOption, Object> channelOptions,
       ChannelInitializer<Channel> channelPipeline,
       boolean isClient) {
-    if (Epoll.isAvailable() && !(eventLoopGroup instanceof EpollEventLoopGroup)) {
-      throw new IllegalArgumentException("eventLoopGroup must be epoll based under Linux");
-    }
-
     AbstractBootstrap b = isClient ? new Bootstrap() : new ServerBootstrap();
     b.group(eventLoopGroup);
 
@@ -70,24 +59,12 @@ public class IPCController {
       }
     }
 
+    // Unix domain sockets require native transport; NativeTransport throws with a clear
+    // message if neither epoll nor kqueue is available.
     if (isClient) {
-      if (Epoll.isAvailable()) {
-        b = b.channel(EpollDomainSocketChannel.class);
-      } else if (KQueue.isAvailable()) {
-        b = b.channel(KQueueDomainSocketChannel.class);
-      } else {
-        throw new RuntimeException(
-            "Neither epoll nor kqueue was found. Unable to initialize channel pipeline");
-      }
+      b = b.channel(NativeTransport.nativeDomainSocketChannelClass());
     } else {
-      if (Epoll.isAvailable()) {
-        b = b.channel(EpollServerDomainSocketChannel.class);
-      } else if (KQueue.isAvailable()) {
-        b = b.channel(KQueueServerDomainSocketChannel.class);
-      } else {
-        throw new RuntimeException(
-            "Neither epoll nor kqueue was found. Unable to initialize server channel pipeline");
-      }
+      b = b.channel(NativeTransport.nativeServerDomainSocketChannelClass());
     }
 
     return isClient

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/IPCController.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/IPCController.java
@@ -59,8 +59,6 @@ public class IPCController {
       }
     }
 
-    // Unix domain sockets require native transport; NativeTransport throws with a clear
-    // message if neither epoll nor kqueue is available.
     if (isClient) {
       b = b.channel(NativeTransport.nativeDomainSocketChannelClass());
     } else {

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi.ipc;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerDomainSocketChannel;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Centralises Netty transport selection: epoll (Linux), kqueue (macOS), or NIO (fallback).
+ *
+ * <p>Unix-domain-socket channels ({@link #nativeDomainSocketChannelClass()}, {@link
+ * #nativeServerDomainSocketChannelClass()}, {@link #nativeEventLoopGroup(int)}) require a native
+ * transport and will throw if neither epoll nor kqueue is available.
+ *
+ * <p>TCP channels ({@link #tcpEventLoopGroup(int)}, {@link #tcpServerSocketChannelClass()}) fall
+ * back to Java NIO when no native transport is available. A warning is logged in that case because
+ * NIO has lower performance and is only suitable for development/testing/lab environments.
+ */
+public final class NativeTransport {
+
+  private static final Logger logger = LoggerFactory.getLogger(NativeTransport.class);
+
+  private static final boolean EPOLL_AVAILABLE = Epoll.isAvailable();
+  private static final boolean KQUEUE_AVAILABLE = KQueue.isAvailable();
+
+  static final String NIO_FALLBACK_WARNING =
+      "Neither epoll nor kqueue is available. Falling back to Java NIO for TCP connections. "
+          + "This results in degraded performance and should only be acceptable in "
+          + "development, testing, or lab environments. Unix domain socket communication "
+          + "requires native transport and will not be available.";
+
+  private NativeTransport() {}
+
+  /** Returns {@code true} if epoll or kqueue is available on this platform. */
+  public static boolean isNativeTransportAvailable() {
+    return EPOLL_AVAILABLE || KQUEUE_AVAILABLE;
+  }
+
+  /**
+   * Returns a native {@link EventLoopGroup} suitable for Unix domain socket communication.
+   *
+   * <p>Uses epoll on Linux and kqueue on macOS/BSD. Throws {@link UnsupportedOperationException} if
+   * neither is available, as Unix domain sockets have no NIO fallback.
+   *
+   * @param nThreads number of threads in the event loop group
+   */
+  public static EventLoopGroup nativeEventLoopGroup(int nThreads) {
+    if (EPOLL_AVAILABLE) {
+      return new EpollEventLoopGroup(nThreads);
+    }
+    if (KQUEUE_AVAILABLE) {
+      return new KQueueEventLoopGroup(nThreads);
+    }
+    throw new UnsupportedOperationException(
+        "Neither epoll nor kqueue is available. Unix domain socket communication requires "
+            + "native transport (epoll on Linux, kqueue on macOS/BSD).");
+  }
+
+  /**
+   * Returns the native {@link io.netty.channel.Channel} class for a Unix domain socket client.
+   *
+   * <p>Throws {@link UnsupportedOperationException} if native transport is unavailable.
+   */
+  public static Class<? extends io.netty.channel.Channel> nativeDomainSocketChannelClass() {
+    if (EPOLL_AVAILABLE) {
+      return EpollDomainSocketChannel.class;
+    }
+    if (KQUEUE_AVAILABLE) {
+      return KQueueDomainSocketChannel.class;
+    }
+    throw new UnsupportedOperationException(
+        "Neither epoll nor kqueue is available. Unix domain socket channels require native "
+            + "transport.");
+  }
+
+  /**
+   * Returns the native {@link io.netty.channel.Channel} class for a Unix domain socket server.
+   *
+   * <p>Throws {@link UnsupportedOperationException} if native transport is unavailable.
+   */
+  public static Class<? extends io.netty.channel.Channel> nativeServerDomainSocketChannelClass() {
+    if (EPOLL_AVAILABLE) {
+      return EpollServerDomainSocketChannel.class;
+    }
+    if (KQUEUE_AVAILABLE) {
+      return KQueueServerDomainSocketChannel.class;
+    }
+    throw new UnsupportedOperationException(
+        "Neither epoll nor kqueue is available. Unix domain socket server channels require "
+            + "native transport.");
+  }
+
+  /**
+   * Returns an {@link EventLoopGroup} for TCP socket connections.
+   *
+   * <p>Prefers native transport (epoll/kqueue) when available. Falls back to Java NIO, logging a
+   * warning that this is only appropriate for development/testing environments.
+   *
+   * @param nThreads number of threads in the event loop group
+   */
+  public static EventLoopGroup tcpEventLoopGroup(int nThreads) {
+    if (EPOLL_AVAILABLE) {
+      return new EpollEventLoopGroup(nThreads);
+    }
+    if (KQUEUE_AVAILABLE) {
+      return new KQueueEventLoopGroup(nThreads);
+    }
+    logger.warn(NIO_FALLBACK_WARNING);
+    return new NioEventLoopGroup(nThreads);
+  }
+
+  /**
+   * Returns the server socket channel class for TCP connections.
+   *
+   * <p>Prefers native transport when available, falls back to {@link NioServerSocketChannel}.
+   */
+  public static Class<? extends ServerChannel> tcpServerSocketChannelClass() {
+    if (EPOLL_AVAILABLE) {
+      return EpollServerSocketChannel.class;
+    }
+    if (KQUEUE_AVAILABLE) {
+      return KQueueServerSocketChannel.class;
+    }
+    return NioServerSocketChannel.class;
+  }
+}

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
@@ -23,15 +23,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Centralises Netty transport selection: epoll (Linux), kqueue (macOS), or NIO (fallback).
+ * Centralises Netty transport selection: epoll (Linux), kqueue (macOS), or NIO (last resort).
+ *
+ * <p>Epoll is the preferred transport. Falling back to kqueue or NIO results in degraded
+ * performance and a warning log. The warning is emitted once at class load time, then suppressed on
+ * subsequent calls to avoid log spam.
  *
  * <p>Unix-domain-socket channels ({@link #nativeDomainSocketChannelClass()}, {@link
- * #nativeServerDomainSocketChannelClass()}, {@link #nativeEventLoopGroup(int)}) require a native
- * transport and will throw if neither epoll nor kqueue is available.
+ * #nativeServerDomainSocketChannelClass()}, {@link #nativeEventLoopGroup(int)}) require native
+ * transport (epoll or kqueue) and will throw {@link UnsupportedOperationException} if neither is
+ * available, because there is no NIO equivalent for Unix domain sockets.
  *
  * <p>TCP channels ({@link #tcpEventLoopGroup(int)}, {@link #tcpServerSocketChannelClass()}) fall
- * back to Java NIO when no native transport is available. A warning is logged in that case because
- * NIO has lower performance and is only suitable for development/testing/lab environments.
+ * back to NIO when no native transport is available.
  */
 public final class NativeTransport {
 
@@ -40,11 +44,21 @@ public final class NativeTransport {
   private static final boolean EPOLL_AVAILABLE = Epoll.isAvailable();
   private static final boolean KQUEUE_AVAILABLE = KQueue.isAvailable();
 
-  static final String NIO_FALLBACK_WARNING =
-      "Neither epoll nor kqueue is available. Falling back to Java NIO for TCP connections. "
-          + "This results in degraded performance and should only be acceptable in "
-          + "development, testing, or lab environments. Unix domain socket communication "
-          + "requires native transport and will not be available.";
+  // Warn once at class-load time whenever epoll is not the active transport.
+  static {
+    if (!EPOLL_AVAILABLE && KQUEUE_AVAILABLE) {
+      logger.warn(
+          "Epoll is not available; falling back to kqueue. This results in degraded performance "
+              + "compared to epoll and should only be acceptable in development, testing, or lab "
+              + "environments.");
+    } else if (!EPOLL_AVAILABLE) {
+      logger.warn(
+          "Neither epoll nor kqueue is available. Falling back to Java NIO for TCP connections. "
+              + "This results in degraded performance and should only be acceptable in "
+              + "development, testing, or lab environments. Unix domain socket communication "
+              + "requires native transport and will not be available.");
+    }
+  }
 
   private NativeTransport() {}
 
@@ -56,8 +70,9 @@ public final class NativeTransport {
   /**
    * Returns a native {@link EventLoopGroup} suitable for Unix domain socket communication.
    *
-   * <p>Uses epoll on Linux and kqueue on macOS/BSD. Throws {@link UnsupportedOperationException} if
-   * neither is available, as Unix domain sockets have no NIO fallback.
+   * <p>Prefers epoll; falls back to kqueue on macOS/BSD. Throws {@link
+   * UnsupportedOperationException} if neither is available, as Unix domain sockets have no NIO
+   * fallback.
    *
    * @param nThreads number of threads in the event loop group
    */
@@ -110,8 +125,8 @@ public final class NativeTransport {
   /**
    * Returns an {@link EventLoopGroup} for TCP socket connections.
    *
-   * <p>Prefers native transport (epoll/kqueue) when available. Falls back to Java NIO, logging a
-   * warning that this is only appropriate for development/testing environments.
+   * <p>Prefers epoll; falls back to kqueue or NIO. The fallback warning is logged once at class
+   * load time.
    *
    * @param nThreads number of threads in the event loop group
    */
@@ -122,14 +137,13 @@ public final class NativeTransport {
     if (KQUEUE_AVAILABLE) {
       return new KQueueEventLoopGroup(nThreads);
     }
-    logger.warn(NIO_FALLBACK_WARNING);
     return new NioEventLoopGroup(nThreads);
   }
 
   /**
    * Returns the server socket channel class for TCP connections.
    *
-   * <p>Prefers native transport when available, falls back to {@link NioServerSocketChannel}.
+   * <p>Prefers epoll; falls back to kqueue or {@link NioServerSocketChannel}.
    */
   public static Class<? extends ServerChannel> tcpServerSocketChannelClass() {
     if (EPOLL_AVAILABLE) {

--- a/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
+++ b/management-api-common/src/main/java/com/datastax/mgmtapi/ipc/NativeTransport.java
@@ -5,6 +5,7 @@
  */
 package com.datastax.mgmtapi.ipc;
 
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.epoll.Epoll;
@@ -19,15 +20,11 @@ import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Centralises Netty transport selection: epoll (Linux), kqueue (macOS), or NIO (last resort).
  *
- * <p>Epoll is the preferred transport. Falling back to kqueue or NIO results in degraded
- * performance and a warning log. The warning is emitted once at class load time, then suppressed on
- * subsequent calls to avoid log spam.
+ * <p>Epoll is the preferred transport. Falling back to kqueue or NIO if available.
  *
  * <p>Unix-domain-socket channels ({@link #nativeDomainSocketChannelClass()}, {@link
  * #nativeServerDomainSocketChannelClass()}, {@link #nativeEventLoopGroup(int)}) require native
@@ -39,26 +36,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class NativeTransport {
 
-  private static final Logger logger = LoggerFactory.getLogger(NativeTransport.class);
-
   private static final boolean EPOLL_AVAILABLE = Epoll.isAvailable();
   private static final boolean KQUEUE_AVAILABLE = KQueue.isAvailable();
-
-  // Warn once at class-load time whenever epoll is not the active transport.
-  static {
-    if (!EPOLL_AVAILABLE && KQUEUE_AVAILABLE) {
-      logger.warn(
-          "Epoll is not available; falling back to kqueue. This results in degraded performance "
-              + "compared to epoll and should only be acceptable in development, testing, or lab "
-              + "environments.");
-    } else if (!EPOLL_AVAILABLE) {
-      logger.warn(
-          "Neither epoll nor kqueue is available. Falling back to Java NIO for TCP connections. "
-              + "This results in degraded performance and should only be acceptable in "
-              + "development, testing, or lab environments. Unix domain socket communication "
-              + "requires native transport and will not be available.");
-    }
-  }
 
   private NativeTransport() {}
 
@@ -83,50 +62,43 @@ public final class NativeTransport {
     if (KQUEUE_AVAILABLE) {
       return new KQueueEventLoopGroup(nThreads);
     }
-    throw new UnsupportedOperationException(
-        "Neither epoll nor kqueue is available. Unix domain socket communication requires "
-            + "native transport (epoll on Linux, kqueue on macOS/BSD).");
+    throw new UnsupportedOperationException("Neither epoll nor kqueue is available.");
   }
 
   /**
-   * Returns the native {@link io.netty.channel.Channel} class for a Unix domain socket client.
+   * Returns the native {@link Channel} class for a Unix domain socket client.
    *
    * <p>Throws {@link UnsupportedOperationException} if native transport is unavailable.
    */
-  public static Class<? extends io.netty.channel.Channel> nativeDomainSocketChannelClass() {
+  public static Class<? extends Channel> nativeDomainSocketChannelClass() {
     if (EPOLL_AVAILABLE) {
       return EpollDomainSocketChannel.class;
     }
     if (KQUEUE_AVAILABLE) {
       return KQueueDomainSocketChannel.class;
     }
-    throw new UnsupportedOperationException(
-        "Neither epoll nor kqueue is available. Unix domain socket channels require native "
-            + "transport.");
+    throw new UnsupportedOperationException("Neither epoll nor kqueue is available.");
   }
 
   /**
-   * Returns the native {@link io.netty.channel.Channel} class for a Unix domain socket server.
+   * Returns the native {@link Channel} class for a Unix domain socket server.
    *
    * <p>Throws {@link UnsupportedOperationException} if native transport is unavailable.
    */
-  public static Class<? extends io.netty.channel.Channel> nativeServerDomainSocketChannelClass() {
+  public static Class<? extends Channel> nativeServerDomainSocketChannelClass() {
     if (EPOLL_AVAILABLE) {
       return EpollServerDomainSocketChannel.class;
     }
     if (KQUEUE_AVAILABLE) {
       return KQueueServerDomainSocketChannel.class;
     }
-    throw new UnsupportedOperationException(
-        "Neither epoll nor kqueue is available. Unix domain socket server channels require "
-            + "native transport.");
+    throw new UnsupportedOperationException("Neither epoll nor kqueue is available.");
   }
 
   /**
    * Returns an {@link EventLoopGroup} for TCP socket connections.
    *
-   * <p>Prefers epoll; falls back to kqueue or NIO. The fallback warning is logged once at class
-   * load time.
+   * <p>Prefers epoll; falls back to kqueue or {@link NioEventLoopGroup}.
    *
    * @param nThreads number of threads in the event loop group
    */

--- a/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/IPCControllerTest.java
+++ b/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/IPCControllerTest.java
@@ -10,10 +10,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
@@ -145,20 +141,10 @@ public class IPCControllerTest {
   }
 
   private static boolean shouldRun() {
-    return Epoll.isAvailable() || KQueue.isAvailable();
+    return NativeTransport.isNativeTransportAvailable();
   }
 
   private EventLoopGroup eventLoop() {
-    if (Epoll.isAvailable()) {
-      Epoll.ensureAvailability();
-      return new EpollEventLoopGroup(1);
-    }
-
-    if (KQueue.isAvailable()) {
-      KQueue.ensureAvailability();
-      return new KQueueEventLoopGroup(1);
-    }
-
-    throw new RuntimeException();
+    return NativeTransport.nativeEventLoopGroup(1);
   }
 }

--- a/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/NativeTransportTest.java
+++ b/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/NativeTransportTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi.ipc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerDomainSocketChannel;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link NativeTransport}.
+ *
+ * <p>Each test uses {@code assumeTrue(isNativeTransportAvailable())} so it is skipped gracefully
+ * when the test JVM cannot load the native library (e.g. CI environments that restrict {@code
+ * setAccessible}). On a normal Linux or macOS developer machine all tests run.
+ */
+public class NativeTransportTest {
+
+  // -------------------------------------------------------------------------
+  // isNativeTransportAvailable
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void isNativeTransportAvailable_returnsTrueOnSupportedPlatform() {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+  }
+
+  // -------------------------------------------------------------------------
+  // nativeEventLoopGroup
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void nativeEventLoopGroup_returnsNativeGroup() throws Exception {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+    EventLoopGroup group = NativeTransport.nativeEventLoopGroup(1);
+    try {
+      assertNotNull(group);
+      assertTrue(
+          "Expected epoll or kqueue EventLoopGroup",
+          group instanceof EpollEventLoopGroup || group instanceof KQueueEventLoopGroup);
+    } finally {
+      group.shutdownGracefully().sync();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // nativeDomainSocketChannelClass
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void nativeDomainSocketChannelClass_returnsCorrectClass() {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+    Class<?> cls = NativeTransport.nativeDomainSocketChannelClass();
+    assertNotNull(cls);
+    assertTrue(cls == EpollDomainSocketChannel.class || cls == KQueueDomainSocketChannel.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // nativeServerDomainSocketChannelClass
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void nativeServerDomainSocketChannelClass_returnsCorrectClass() {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+    Class<?> cls = NativeTransport.nativeServerDomainSocketChannelClass();
+    assertNotNull(cls);
+    assertTrue(
+        cls == EpollServerDomainSocketChannel.class
+            || cls == KQueueServerDomainSocketChannel.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // tcpEventLoopGroup — prefers native; falls back to NIO
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void tcpEventLoopGroup_returnsNativeGroup() throws Exception {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+    EventLoopGroup group = NativeTransport.tcpEventLoopGroup(1);
+    try {
+      assertNotNull(group);
+      assertFalse("Expected native (not NIO) group", group instanceof NioEventLoopGroup);
+    } finally {
+      group.shutdownGracefully().sync();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // tcpServerSocketChannelClass — prefers native; falls back to NIO
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void tcpServerSocketChannelClass_returnsNativeClass() {
+    assumeTrue(NativeTransport.isNativeTransportAvailable());
+    Class<? extends ServerChannel> cls = NativeTransport.tcpServerSocketChannelClass();
+    assertNotNull(cls);
+    assertTrue(cls == EpollServerSocketChannel.class || cls == KQueueServerSocketChannel.class);
+  }
+}

--- a/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/NativeTransportTest.java
+++ b/management-api-common/src/test/java/com/datastax/mgmtapi/ipc/NativeTransportTest.java
@@ -25,10 +25,6 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link NativeTransport}.
- *
- * <p>Each test uses {@code assumeTrue(isNativeTransportAvailable())} so it is skipped gracefully
- * when the test JVM cannot load the native library (e.g. CI environments that restrict {@code
- * setAccessible}). On a normal Linux or macOS developer machine all tests run.
  */
 public class NativeTransportTest {
 

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -5,6 +5,7 @@
  */
 package com.datastax.mgmtapi;
 
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import com.datastax.mgmtapi.util.ShellUtils;
 import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.SingleCommand;
@@ -28,10 +29,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.ssl.ClientAuth;
@@ -293,16 +290,12 @@ public class Cli implements Runnable {
       System.exit(3);
     }
 
-    if (PlatformDependent.isOsx()) {
-      if (!KQueue.isAvailable()) {
-        System.err.println("Missing KQueue netty libraries");
-        System.exit(3);
-      }
-    } else {
-      if (!Epoll.isAvailable()) {
-        System.err.println("Missing Epoll netty libraries");
-        System.exit(3);
-      }
+    if (!NativeTransport.isNativeTransportAvailable()) {
+      logger.warn(
+          "Native transport (epoll on Linux, kqueue on macOS/BSD) is not available. "
+              + "Falling back to Java NIO for TCP connections. Unix domain socket "
+              + "communication with Cassandra will not be available. "
+              + "This fallback is only acceptable in development, testing, or lab environments.");
     }
   }
 
@@ -583,8 +576,7 @@ public class Cli implements Runnable {
   }
 
   private NettyJaxrsServer startHTTPService(File socketFile) {
-    EventLoopGroup loopGroup =
-        PlatformDependent.isOsx() ? new KQueueEventLoopGroup(2) : new EpollEventLoopGroup(2);
+    EventLoopGroup loopGroup = NativeTransport.nativeEventLoopGroup(2);
 
     NettyJaxrsServer server = new NettyJaxrsIPCServer(loopGroup, socketFile);
     ResteasyDeployment deployment = new ResteasyDeploymentImpl();

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/Cli.java
@@ -291,11 +291,8 @@ public class Cli implements Runnable {
     }
 
     if (!NativeTransport.isNativeTransportAvailable()) {
-      logger.warn(
-          "Native transport (epoll on Linux, kqueue on macOS/BSD) is not available. "
-              + "Falling back to Java NIO for TCP connections. Unix domain socket "
-              + "communication with Cassandra will not be available. "
-              + "This fallback is only acceptable in development, testing, or lab environments.");
+      logger.error("Native transport is not available.");
+      System.exit(3);
     }
   }
 

--- a/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
+++ b/management-api-server/src/main/java/com/datastax/mgmtapi/UnixSocketCQLAccess.java
@@ -7,6 +7,7 @@ package com.datastax.mgmtapi;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
@@ -41,12 +42,6 @@ import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan;
 import com.google.common.collect.Maps;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollDomainSocketChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueDomainSocketChannel;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -238,9 +233,7 @@ public class UnixSocketCQLAccess {
 
         @Override
         public Class<? extends Channel> channelClass() {
-          return Epoll.isAvailable()
-              ? EpollDomainSocketChannel.class
-              : KQueueDomainSocketChannel.class;
+          return NativeTransport.nativeDomainSocketChannelClass();
         }
 
         @Override
@@ -388,16 +381,6 @@ public class UnixSocketCQLAccess {
   }
 
   private static EventLoopGroup eventLoop() {
-    if (Epoll.isAvailable()) {
-      Epoll.ensureAvailability();
-      return new EpollEventLoopGroup(2);
-    }
-
-    if (KQueue.isAvailable()) {
-      KQueue.ensureAvailability();
-      return new KQueueEventLoopGroup(2);
-    }
-
-    throw new RuntimeException();
+    return NativeTransport.nativeEventLoopGroup(2);
   }
 }

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/CliCheckNettyDepsTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/CliCheckNettyDepsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Please see the included license file for details.
+ */
+package com.datastax.mgmtapi;
+
+import static org.junit.Assert.fail;
+
+import java.security.Permission;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Cli#checkNettyDeps()}.
+ *
+ * <p>The method calls {@link System#exit(int)} on failure. We intercept that with a minimal {@link
+ * SecurityManager} that converts the call into a testable {@link ExitException}.
+ */
+public class CliCheckNettyDepsTest {
+
+  /** Thrown by {@link NoExitSecurityManager} instead of actually halting the JVM. */
+  static final class ExitException extends SecurityException {
+    final int status;
+
+    ExitException(int status) {
+      super("System.exit(" + status + ") intercepted");
+      this.status = status;
+    }
+  }
+
+  /**
+   * Blocks {@code System.exit} by throwing {@link ExitException}. All other permission checks are
+   * delegated to the original manager (or silently allowed when there is none).
+   */
+  static final class NoExitSecurityManager extends SecurityManager {
+    private final SecurityManager delegate;
+
+    NoExitSecurityManager(SecurityManager delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void checkExit(int status) {
+      throw new ExitException(status);
+    }
+
+    @Override
+    public void checkPermission(Permission perm) {
+      if (delegate != null) {
+        delegate.checkPermission(perm);
+      }
+    }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+      if (delegate != null) {
+        delegate.checkPermission(perm, context);
+      }
+    }
+  }
+
+  private SecurityManager originalManager;
+
+  @Before
+  public void installNoExitManager() {
+    originalManager = System.getSecurityManager();
+    System.setSecurityManager(new NoExitSecurityManager(originalManager));
+  }
+
+  @After
+  public void restoreSecurityManager() {
+    System.setSecurityManager(originalManager);
+  }
+
+  @Test
+  public void checkNettyDeps_doesNotExitWhenNativeTransportAvailable() {
+    try {
+      new Cli().checkNettyDeps();
+    } catch (ExitException e) {
+      fail("checkNettyDeps() called System.exit(" + e.status + ") unexpectedly");
+    }
+  }
+}

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/NettyHttpOverIPCTest.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/NettyHttpOverIPCTest.java
@@ -8,16 +8,13 @@ package com.datastax.mgmtapi;
 import static org.jboss.resteasy.test.TestPortProvider.generateURL;
 
 import com.datastax.mgmtapi.ipc.IPCController;
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -192,21 +189,11 @@ public class NettyHttpOverIPCTest {
   }
 
   private static boolean shouldRun() {
-    return Epoll.isAvailable() || KQueue.isAvailable();
+    return NativeTransport.isNativeTransportAvailable();
   }
 
   private EventLoopGroup eventLoop() {
-    if (Epoll.isAvailable()) {
-      Epoll.ensureAvailability();
-      return new EpollEventLoopGroup(1);
-    }
-
-    if (KQueue.isAvailable()) {
-      KQueue.ensureAvailability();
-      return new KQueueEventLoopGroup(1);
-    }
-
-    throw new RuntimeException();
+    return NativeTransport.nativeEventLoopGroup(1);
   }
 
   @Path("/")

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/IntegrationTestUtils.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/IntegrationTestUtils.java
@@ -5,9 +5,8 @@
  */
 package com.datastax.mgmtapi.helpers;
 
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import com.google.common.collect.ImmutableList;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.kqueue.KQueue;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -20,22 +19,7 @@ public class IntegrationTestUtils {
   private static final Logger logger = LoggerFactory.getLogger(IntegrationTestUtils.class);
 
   public static boolean shouldRun() {
-    boolean epollAvailable = false;
-    boolean kqueueAvailable = false;
-
-    try {
-      epollAvailable = Epoll.isAvailable();
-    } catch (Exception e) {
-      logger.debug("Epoll is not available", e);
-    }
-
-    try {
-      kqueueAvailable = KQueue.isAvailable();
-    } catch (Exception e) {
-      logger.debug("KQueue is not available", e);
-    }
-
-    return epollAvailable || kqueueAvailable;
+    return NativeTransport.isNativeTransportAvailable();
   }
 
   public static List<String> getExtraArgs(Class testClass, String suffix, File tempDir) {

--- a/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpIPCClient.java
+++ b/management-api-server/src/test/java/com/datastax/mgmtapi/helpers/NettyHttpIPCClient.java
@@ -8,16 +8,13 @@ package com.datastax.mgmtapi.helpers;
 import static org.junit.Assert.fail;
 
 import com.datastax.mgmtapi.ipc.IPCController;
+import com.datastax.mgmtapi.ipc.NativeTransport;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueue;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
@@ -176,16 +173,6 @@ public class NettyHttpIPCClient {
   }
 
   private EventLoopGroup eventLoop() {
-    if (Epoll.isAvailable()) {
-      Epoll.ensureAvailability();
-      return new EpollEventLoopGroup(1);
-    }
-
-    if (KQueue.isAvailable()) {
-      KQueue.ensureAvailability();
-      return new KQueueEventLoopGroup(1);
-    }
-
-    throw new RuntimeException();
+    return NativeTransport.nativeEventLoopGroup(1);
   }
 }


### PR DESCRIPTION
- abstracts sockets & event loops into class NativeTransport
- uses epoll if available, kqueue next and fallback to nio if possible
- logs warning if neither epoll nor kqueue is available
Fixes #430 
